### PR TITLE
None -> undefined.

### DIFF
--- a/gen_js_api.ml
+++ b/gen_js_api.ml
@@ -622,7 +622,7 @@ let def s ty body =
 
 let builtin_type = function
   | "int" | "string" | "bool" | "float"
-  | "array" | "list" | "option" | "Ojs.optdef" -> true
+  | "array" | "list" | "option" -> true
   | _ -> false
 
 let let_exp_in exp f =

--- a/gen_js_api.ml
+++ b/gen_js_api.ml
@@ -622,7 +622,7 @@ let def s ty body =
 
 let builtin_type = function
   | "int" | "string" | "bool" | "float"
-  | "array" | "list" | "option" | "optdef" -> true
+  | "array" | "list" | "option" | "Ojs.optdef" -> true
   | _ -> false
 
 let let_exp_in exp f =
@@ -774,7 +774,7 @@ and gen_args ?(name = fun _ -> fresh ()) ?(map = ml2js) args =
       match label with
       | Nolabel
       | Labelled _ -> ty
-      | Optional _ -> Name ("optdef", [ty])
+      | Optional _ -> Name ("Ojs.optdef", [ty])
     in
     (label, s), (label, js_label, map ty (var s))
   in

--- a/gen_js_api.ml
+++ b/gen_js_api.ml
@@ -622,7 +622,7 @@ let def s ty body =
 
 let builtin_type = function
   | "int" | "string" | "bool" | "float"
-  | "array" | "list" | "option" -> true
+  | "array" | "list" | "option" | "optdef" -> true
   | _ -> false
 
 let let_exp_in exp f =
@@ -774,7 +774,7 @@ and gen_args ?(name = fun _ -> fresh ()) ?(map = ml2js) args =
       match label with
       | Nolabel
       | Labelled _ -> ty
-      | Optional _ -> Name ("option", [ty])
+      | Optional _ -> Name ("optdef", [ty])
     in
     (label, s), (label, js_label, map ty (var s))
   in
@@ -1052,7 +1052,7 @@ and gen_def loc decl ty =
             | Some s, _ -> s
           in
           let code exp = ojs "set" [x; str js_label; ml2js ty exp] in
-          (* special logic to avoid setting optional argument to 'null' *)
+          (* special logic to avoid setting optional argument to 'undefined' *)
           match label with
           | Optional _ -> match_some_none (var s) ~none:unit_expr ~some:code
           | Nolabel | Labelled _ -> code (var s)

--- a/ojs.ml
+++ b/ojs.ml
@@ -92,6 +92,8 @@ let option_to_js f = function
   | Some x -> f x
   | None -> null
 
+type 'a optdef = 'a option
+
 let optdef_of_js = option_of_js
 let optdef_to_js f = function
   | Some x -> f x

--- a/ojs.ml
+++ b/ojs.ml
@@ -90,6 +90,11 @@ let option_of_js f x =
 
 let option_to_js f = function
   | Some x -> f x
+  | None -> null
+
+let optdef_of_js = option_of_js
+let optdef_to_js f = function
+  | Some x -> f x
   | None -> undefined
 
 class obj (x:t) =

--- a/ojs.ml
+++ b/ojs.ml
@@ -90,7 +90,7 @@ let option_of_js f x =
 
 let option_to_js f = function
   | Some x -> f x
-  | None -> null
+  | None -> undefined
 
 class obj (x:t) =
   object

--- a/ojs.mli
+++ b/ojs.mli
@@ -35,6 +35,11 @@ val option_of_js: (t -> 'a) -> t -> 'a option
 val option_to_js: ('a -> t) -> 'a option -> t
 (** [None] is mapped to [null]. *)
 
+val optdef_of_js: (t -> 'a) -> t -> 'a option
+(** Both [null] and [undefined] are mapped to [None]. *)
+val optdef_to_js: ('a -> t) -> 'a option -> t
+(** [None] is mapped to [undefined]. *)
+
 external fun_to_js: int -> (t -> 'a) -> t = "caml_js_wrap_callback_strict"
 (** Wrap an OCaml function of known arity (>=1) into a JS function.
     Extra arguments are discarded and missing argument are filled with

--- a/ojs.mli
+++ b/ojs.mli
@@ -35,6 +35,8 @@ val option_of_js: (t -> 'a) -> t -> 'a option
 val option_to_js: ('a -> t) -> 'a option -> t
 (** [None] is mapped to [null]. *)
 
+type 'a optdef = 'a option
+
 val optdef_of_js: (t -> 'a) -> t -> 'a option
 (** Both [null] and [undefined] are mapped to [None]. *)
 val optdef_to_js: ('a -> t) -> 'a option -> t


### PR DESCRIPTION
I suggest to modify representation of None in JS: undefined instead of null. Otherwise, we have a problem with JS function taking optional argument (for instance String.lastIndexOf behaves badly if the default value for start is set to null, whereas it works correctly when set to undefined).
I am not sure it is the right fix to this problem though...
