### PR TITLE
Fix broken link syntax in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Documentation
   - [JS-able types and type declarations](TYPES.md)
   - [Value bindings](VALUES.md)
   - [Class-wrapping bindings](CLASSES.md)
-  - [TODO list] (TODO.md)
+  - [TODO list](TODO.md)
 
 
 Related projects


### PR DESCRIPTION
The BuckleScript and the TODO ones.