### PR TITLE
Adds travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.08 PACKAGE=gen_js_api
+  - OCAML_VERSION=4.09 PACKAGE=gen_js_api
+  - OCAML_VERSION=4.10 PACKAGE=gen_js_api
+os:
+  - linux

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 gen_js_api: easy OCaml bindings for Javascript libraries
 ========================================================
 
+[![Build Status](https://travis-ci.com/LexiFi/gen_js_api.svg?branch=master)](https://travis-ci.com/LexiFi/gen_js_api)
+
 Overview
 --------
 

--- a/dune-workspace.dev
+++ b/dune-workspace.dev
@@ -1,0 +1,5 @@
+(lang dune 1.2)
+(context (opam (switch 4.08.0)))
+(context (opam (switch 4.09.0)))
+(context (opam (switch 4.10.0)))
+(context (opam (switch default)))

--- a/ppx-lib/dune
+++ b/ppx-lib/dune
@@ -1,5 +1,5 @@
 (library
   (name gen_js_api_ppx)
   (public_name gen_js_api.ppx-lib)
-  (libraries compiler-libs.common)
+  (libraries ocaml-migrate-parsetree)
   (preprocess no_preprocessing))

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -2,6 +2,8 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
+open Migrate_parsetree.Ast_408
+
 open Location
 open Asttypes
 open Parsetree
@@ -1552,6 +1554,14 @@ let specs =
 
 let usage = "gen_js_api [-o mymodule.ml] mymodule.mli"
 
+let from_current =
+  let open Migrate_parsetree in
+  Versions.migrate Versions.ocaml_current Versions.ocaml_408
+
+let to_current =
+  let open Migrate_parsetree in
+  Versions.migrate Versions.ocaml_408 Versions.ocaml_current
+
 let standalone () =
   let files = ref [] in
   Arg.parse specs (fun s -> files := s :: !files) usage;
@@ -1566,12 +1576,12 @@ let standalone () =
   let sg =
     Pparse.parse_interface
       ~tool_name:"gen_js_iface"
-      src
+      src |> from_current.Migrate_parsetree.Versions.copy_signature
   in
   let str = str_of_sg ~global_attrs:[] sg in
   ignore (check_loc_mapper.Ast_mapper.signature check_loc_mapper sg);
   let str = clear_attr_mapper.Ast_mapper.structure clear_attr_mapper str in
-  Format.fprintf (Format.formatter_of_out_channel oc) "%a@." Pprintast.structure str;
+  Format.fprintf (Format.formatter_of_out_channel oc) "%a@." Pprintast.structure (to_current.copy_structure str);
   if !out <> "-" then close_out oc
 
 

--- a/ppx-lib/gen_js_api_ppx.mli
+++ b/ppx-lib/gen_js_api_ppx.mli
@@ -2,6 +2,6 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
-val mapper : Ast_mapper.mapper
+val mapper : Migrate_parsetree.Ast_408.Ast_mapper.mapper
 
 val standalone : unit -> unit

--- a/ppx-standalone/gen_js_api.ml
+++ b/ppx-standalone/gen_js_api.ml
@@ -2,6 +2,8 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
+open Migrate_parsetree.Ast_408
+
 let () =
   try
     if Array.length Sys.argv < 4 || Sys.argv.(1) <> "-ppx" then Gen_js_api_ppx.standalone ()


### PR DESCRIPTION
This PR tries to set-up travis and allow to compile gen_js_api with more compiler versions through a better use of ocaml-migrate-parsetree.