### PR TITLE
Fix locations to pass ppxlib locations invariant checks

### DIFF
--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -9,12 +9,17 @@ let copy_attribute (a : Migrate_parsetree.Ast_408.Parsetree.attribute)
   List.hd pat.ppat_attributes
 
 let check_attributes_with_ppxlib = false
+let check_locations_with_ppxlib = false
 
 let () =
   if check_attributes_with_ppxlib
   then (
     Ppxlib.Driver.enable_checks ();
     Gen_js_api_ppx.check_attribute := false
+  );
+  if check_locations_with_ppxlib
+  then (
+    Ppxlib.Driver.enable_location_check ()
   );
   Gen_js_api_ppx.mark_as_handled_manually := (fun attribute ->
     let attribute = copy_attribute attribute in


### PR DESCRIPTION
Here is explanation for the check (as found in
https://github.com/ocaml-ppx/ppxlib/blob/master/src/location_check.mli)

```
(** Enforces some invariants on AST nodes locations *)

(** {2 What?}
    The invariants are as follow:
    - AST nodes are requested to be well nested wrt. locations
    - the locations of "sibling" AST nodes should not overlap
    {2 Why?}
    This is required for merlin to behave properly.
    Indeed, for almost any query directed at merlin, it will need to inspect the
    context around the user's cursor to give an answer that makes sense. And the
    only input it has to do that is the position of the cursor in the buffer.
    The handling of most queries starts by traversing the AST, using the
    locations of nodes to select the right branch. (1) is necessary to avoid
    discarding subtrees too early, (2) is used to avoid merlin making arbitrary
    choices (if you ask for the type under the cursor, and there seem to be two
    things under the cursor, merlin will need to pick one).
    {2 Guidelines for writing well-behaved ppxes}
    It's obviously not always (indeed rarely) possible to mint new locations
    when manipulating the AST.
    The intended way to deal with locations is this:
    - AST nodes that exist in the source should keep their original location
    - new nodes should be given a "ghost" location (i.e.
    [{ some_loc with loc_ghost = true }]) to indicate that the node doesn't
    exist in the sources.
    Both the new check and merlin will happily traverse these ghost nodes as if
    they didn't exist.
    Note: this comes into play when deciding which nodes are "siblings", for
    instance if your AST is:
    {v
      A (B1(C, D),
         B2(X, Y))
    v}
    but [B2] has a ghost location, then [B1], [X] and [Y] are considered
    siblings.
    Additionally, there is an attribute [[@merlin.hide]] that you can add on
    nodes to tell merlin (and the check) to ignore this node and all of its
    children.
    Some helpers for this are provided in {!Merlin_helpers}.
*)
```