### PR TITLE
Better ppxlib integration 

### DIFF
--- a/examples/misc/test_jquery.ml
+++ b/examples/misc/test_jquery.ml
@@ -6,8 +6,10 @@
 
 open Jquery
 
+include [%js:
 val alert: string -> unit
   [@@js.global]
+]
 
 let ( !! ) = Jquery.selector
 

--- a/examples/test/main.ml
+++ b/examples/test/main.ml
@@ -40,6 +40,7 @@ let () =
   test_variadic sum;
   test_variadic2 (fun msg xs -> Printf.printf "%s\n%!" msg; sum xs)
 
+include [%js:
 val myArray: int array
     [@@js]
 
@@ -55,6 +56,7 @@ val alert_float: float -> unit
 
 val test_opt_args: (?foo:int -> ?bar:int -> unit-> string) -> unit
   [@@js.global]
+]
 
 let doc = Window.document window
 
@@ -215,6 +217,7 @@ end = struct
     !l
 end
 
+include [%js:
 val int_dict_to_json_string: int Dict.t -> string
   [@@js.global "JSON.stringify"]
 
@@ -226,6 +229,7 @@ val set_x: int -> unit
 
 val get_x: unit -> int
     [@@js.get "x"]
+]
 
 let () =
   print_endline (int_dict_to_json_string ["hello", 1; "world", 2]);
@@ -252,11 +256,13 @@ let print = function
   | C (n, s) -> print_endline (Format.sprintf "C (%d, %S)" n s)
   | D {age; name} -> print_endline (Format.sprintf "D {age = %d; name = %S}" age name)
 
+include [%js:
 val set_print_sum: (t -> unit) -> unit
     [@@js.set "print_sum"]
 
 val test_sum: unit -> unit
     [@@js.global "test_sum"]
+]
 
 let () =
   set_print_sum print
@@ -276,8 +282,10 @@ let () =
   Console3.log4 1 "two" [] [|4|];
 end
 
+include [%js:
 val test_flatten: ([`A | `B of int | `C of string | `D of int * string] [@js.enum]) -> unit
     [@@js.global "test_flatten"]
+]
 
 let () =
   test_flatten `A;

--- a/examples/test/main.ml
+++ b/examples/test/main.ml
@@ -292,8 +292,9 @@ let () =
   test_flatten (`B 42);
   test_flatten (`C "hello");
   test_flatten (`D (42, "foo"))
-
+include [%js:
 val make_string : 'a -> string [@@js.global "String"]
+]
 
 let () =
   Console3.log (make_string 1234);
@@ -301,8 +302,10 @@ let () =
   Console3.log (make_string ["list"]);
   Console3.log (make_string [|"array"|])
 
+include [%js:
 val test_typvars: 'a -> 'a * 'a
     [@@js.global "test_typvars"]
+]
 
 let () =
   Console3.log (test_typvars `A);

--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -1,4 +1,5 @@
-module Selected = Ppxlib.Select_ast(Migrate_parsetree.Versions.OCaml_408)
+module From_ppx = Migrate_parsetree.Versions.OCaml_408
+module Selected = Ppxlib.Select_ast(From_ppx)
 
 let copy_attribute (a : Migrate_parsetree.Ast_408.Parsetree.attribute)
   : Ppxlib.Ast.attribute =
@@ -27,6 +28,10 @@ let () =
   let mapper_for_sig =
     Selected.Of_ocaml.copy_mapper
       (Gen_js_api_ppx.mark_attributes_as_used Gen_js_api_ppx.mapper)
+  in
+  let mapper_for_str =
+    Selected.Of_ocaml.copy_mapper
+      (Gen_js_api_ppx.mark_attributes_as_used From_ppx.Ast.Ast_mapper.default_mapper)
   in
   let copy_module_expr m =
     match
@@ -93,5 +98,7 @@ let () =
   Ppxlib.Driver.register_transformation
     "gen_js_api"
     ~rules:[module_expr_ext; ext_of; ext_to; attr_typ ]
+    ~impl:(fun str_ ->
+      mapper_for_str.structure mapper_for_str str_)
     ~intf:(fun sig_ ->
       mapper_for_sig.signature mapper_for_sig sig_)

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -1579,13 +1579,13 @@ and module_expr_rewriter ~loc ~attrs sg =
 
 and js_to_rewriter ~loc ty =
   let e' = with_default_loc {loc with loc_ghost = true }
-      (fun () -> js2ml_fun (parse_typ ~global_attrs:[] ty))
+      (fun () -> js2ml_fun [] (parse_typ ~global_attrs:[] ty))
   in
   { e' with pexp_loc = loc }
 
 and js_of_rewriter ~loc ty =
   let e' = with_default_loc {loc with loc_ghost = true}
-      (fun () -> ml2js_fun (parse_typ ~global_attrs:[] ty))
+      (fun () -> ml2js_fun [] (parse_typ ~global_attrs:[] ty))
   in
   { e' with pexp_loc = loc  }
 

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -14,7 +14,6 @@ open! Ast_helper
 
 type error =
   | Expression_expected
-  | Type_expected
   | Identifier_expected
   | Structure_expected
   | Invalid_expression
@@ -90,10 +89,6 @@ let expr_of_payload loc = function
   | PStr [x] -> expr_of_stritem x
   | _ -> error loc Expression_expected
 
-let typ_of_payload loc = function
-  | PTyp x -> x
-  | _ -> error loc Type_expected
-
 let str_of_payload loc = function
   | PStr x -> x
   | _ -> error loc Structure_expected
@@ -122,8 +117,6 @@ let get_string_attribute_default key default attrs =
 let print_error ppf = function
   | Expression_expected ->
       Format.fprintf ppf "Expression expected"
-  | Type_expected ->
-      Format.fprintf ppf "Type expression expected"
   | Structure_expected ->
       Format.fprintf ppf "Structure expected"
   | Identifier_expected ->
@@ -1605,12 +1598,7 @@ and mapper =
   let open Ast_mapper in
   let super = default_mapper in
 
-  let typ self ct =
-    let ct = super.typ self ct in
-    match get_attribute "js.replace" ct.ptyp_attributes with
-    | None -> ct
-    | Some (k, v) -> typ_of_payload k.loc v
-  and module_expr self mexp =
+  let module_expr self mexp =
     let mexp = super.module_expr self mexp in
     match mexp.pmod_desc with
     | Pmod_extension ({txt = "js"; _}, PSig sg) ->
@@ -1654,7 +1642,7 @@ and mapper =
     ignore (filter_attr "js.dummy" a : bool);
     super.attribute self a
   in
-  {super with module_expr; structure_item; expr; typ; attribute}
+  {super with module_expr; structure_item; expr; attribute}
 
 let is_js_attribute txt = txt = "js" || has_prefix ~prefix:"js." txt
 

--- a/ppx-lib/gen_js_api_ppx.mli
+++ b/ppx-lib/gen_js_api_ppx.mli
@@ -8,6 +8,28 @@ val check_attribute : bool ref
 
 val mapper : Migrate_parsetree.Ast_408.Ast_mapper.mapper
 
+val module_expr_rewriter
+  :  loc:Location.t
+  -> attrs:Migrate_parsetree.Ast_408.Parsetree.attributes
+  -> Migrate_parsetree.Ast_408.Parsetree.signature
+  -> Migrate_parsetree.Ast_408.Parsetree.module_expr
+
+val js_of_rewriter
+  :  loc:Location.t
+  -> Migrate_parsetree.Ast_408.Parsetree.core_type
+  -> Migrate_parsetree.Ast_408.Parsetree.expression
+
+val js_to_rewriter
+  :  loc:Location.t
+  -> Migrate_parsetree.Ast_408.Parsetree.core_type
+  -> Migrate_parsetree.Ast_408.Parsetree.expression
+
+val type_decl_rewriter
+  :  loc:Location.t
+  -> Migrate_parsetree.Ast_408.Asttypes.rec_flag
+  -> Migrate_parsetree.Ast_408.Parsetree.type_declaration list
+  -> Migrate_parsetree.Ast_408.Parsetree.structure
+
 val mark_attributes_as_used
   :  Migrate_parsetree.Ast_408.Ast_mapper.mapper
   -> Migrate_parsetree.Ast_408.Ast_mapper.mapper


### PR DESCRIPTION
Better integration with ppxlib. Fix #107
 
As a result, the following syntax changes were made when using the ppxlib driver:
- `val name : ty [@@js...]` in structure is now only supported inside `[%js ]` extension nodes
- `type t [@@js]` in structure not longer expand to `type t = Ojs.t [@@js]`, one need to add the type equality explicitly 
- `[@js replace]`  in structure is now only supported inside `[%js]` extension nodes 