### PR TITLE
Dependency tweaks

### DIFF
--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -14,8 +14,9 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
-  "ocaml-migrate-parsetree" {>= "1.6.0"}
+  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ppxlib" {>= "0.9"}
+  "js_of_ocaml-compiler" { > "3.0" }
 ]
 synopsis: "Easy OCaml bindings for Javascript libraries"
 description: """

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ppxlib" {>= "0.9"}
+  "js_of_ocaml-compiler" { with-test & >= "3.0" }
 ]
 conflicts: [
   "js_of_ocaml-compiler" { < "3.0" }

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -14,7 +14,6 @@ build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "2.0"}
-  "js_of_ocaml"  {>= "3.1.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ppxlib" {>= "0.9"}
 ]

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -16,7 +16,9 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "ppxlib" {>= "0.9"}
-  "js_of_ocaml-compiler" { > "3.0" }
+]
+conflicts: [
+  "js_of_ocaml-compiler" { < "3.0" }
 ]
 synopsis: "Easy OCaml bindings for Javascript libraries"
 description: """

--- a/ppx-driver/dune
+++ b/ppx-driver/dune
@@ -2,6 +2,6 @@
   (name gen_js_api_ppx_driver)
   (public_name gen_js_api.ppx)
   (synopsis "Syntactic support for gen_js_api")
-  (libraries compiler-libs.common gen_js_api.ppx-lib ppxlib)
+  (libraries ocaml-migrate-parsetree gen_js_api.ppx-lib ppxlib.ast ppxlib)
   (kind ppx_rewriter)
   (preprocess no_preprocessing))

--- a/ppx-lib/dune
+++ b/ppx-lib/dune
@@ -1,5 +1,5 @@
 (library
   (name gen_js_api_ppx)
   (public_name gen_js_api.ppx-lib)
-  (libraries ocaml-migrate-parsetree)
+  (libraries compiler-libs.common ocaml-migrate-parsetree)
   (preprocess no_preprocessing))

--- a/ppx-standalone/dune
+++ b/ppx-standalone/dune
@@ -1,8 +1,7 @@
 (executables
   (names gen_js_api)
   (public_names gen_js_api)
-  (libraries gen_js_api.ppx)
-  )
+  (libraries compiler-libs.common ocaml-migrate-parsetree gen_js_api.ppx-lib))
 
 (install
   (section libexec)


### PR DESCRIPTION
* Do not rely on implicit transitive dependencies. Makes it clear what exactly
  depends on omp, ppxlib, and compiler-libs.
* Remove dependency on jsoo. As far as I can tell, it's not used anywhere.