### PR TITLE
Register js as a deriver

### DIFF
--- a/ppx-lib/gen_js_api_ppx.mli
+++ b/ppx-lib/gen_js_api_ppx.mli
@@ -30,6 +30,11 @@ val type_decl_rewriter
   -> Migrate_parsetree.Ast_411.Parsetree.type_declaration list
   -> Migrate_parsetree.Ast_411.Parsetree.structure
 
+val type_decl_sig_rewriter
+  :  loc:Location.t
+  -> Migrate_parsetree.Ast_411.Parsetree.type_declaration list
+  -> Migrate_parsetree.Ast_411.Parsetree.signature
+
 val mark_attributes_as_used
   :  Migrate_parsetree.Ast_411.Ast_mapper.mapper
   -> Migrate_parsetree.Ast_411.Ast_mapper.mapper


### PR DESCRIPTION
# Context 

This PR allows to user [@@deriving js] to generate the conversion functions. 
This is helpful to avoid writing their signature in interfaces (see issue #116) but it integrates better in the ecosystem. 

# Example 

## Before 
In signature:
```ocaml 
 type ('a, 'b) t = { x : 'a; y : 'b }
 val t_of_js : (Ojs.t -> 'a) -> (Ojs.t -> 'b) -> Ojs.t -> ('a, 'b) t
 val t_to_js : ('a -> Ojs.t) -> ('b -> Ojs.t) -> ('a, 'b) t -> Ojs.t
```
and in structure : 
```ocaml 
 type ('a, 'b) t = { x : 'a; y : 'b } [@js] 
```

## After
In both signture and structure: 
```ocaml 
 type ('a, 'b) t = { x : 'a; y : 'b } [@@deriving js]
```
This attributes works in preprossed ml/mli files. 
It also works through the "standalone" tool although the resulting implementation file will still need to be preprocessed by the ppx.  

