### PR TITLE
Retrieve backward compatibility

### DIFF
--- a/INSTALL_AND_USE.md
+++ b/INSTALL_AND_USE.md
@@ -53,7 +53,7 @@ Usage (with dune)
      (names test_jquery)
      (js_of_ocaml)
      (libraries ojs js_of_ocaml)
-     (preprocess (pps gen_js_api))
+     (preprocess (pps gen_js_api.ppx))
      (modes byte)
    )
    ```

--- a/dune
+++ b/dune
@@ -1,3 +1,7 @@
 (env
  (dev
   (flags (:standard))))
+
+(deprecated_library_name
+ (old_public_name gen_js_api)
+ (new_public_name ojs))

--- a/examples/calc/dune
+++ b/examples/calc/dune
@@ -3,7 +3,7 @@
  (libraries ojs)
  (link_flags -no-check-prims)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes js))
 
 (rule

--- a/examples/misc/dune
+++ b/examples/misc/dune
@@ -3,7 +3,7 @@
  (libraries ojs)
  (link_flags -no-check-prims)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes js))
 
 (rule

--- a/examples/test/dune
+++ b/examples/test/dune
@@ -3,7 +3,7 @@
  (libraries ojs)
  (link_flags -no-check-prims)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes js))
 
 (rule

--- a/node-test/bindings/dune
+++ b/node-test/bindings/dune
@@ -1,9 +1,9 @@
 (library
  (name node)
  (synopsis "Bindings")
- (libraries gen_js_api)
+ (libraries ojs)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes byte)
  (js_of_ocaml
   (javascript_files imports.js)))

--- a/node-test/test1/dune
+++ b/node-test/test1/dune
@@ -1,9 +1,9 @@
 (executable
  (name test)
- (libraries gen_js_api node)
+ (libraries ojs node)
  (link_flags -no-check-prims)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes js))
 
 (rule

--- a/node-test/test1/test.ml
+++ b/node-test/test1/test.ml
@@ -82,7 +82,7 @@ let () =
 let uncaught_handler p =
   let open Promise in
   catch p (fun error ->
-      Printf.eprintf "Uncaught execption: %s\n" (Printexc.to_string (Obj.magic error));
+      Printf.eprintf "Uncaught exception: %s\n" (Printexc.to_string (Obj.magic error));
       exit 1
     )
 

--- a/ppx-driver/dune
+++ b/ppx-driver/dune
@@ -1,6 +1,6 @@
 (library
  (name gen_js_api_ppx_driver)
- (public_name gen_js_api)
+ (public_name gen_js_api.ppx)
  (synopsis "Syntactic support for gen_js_api")
  (libraries ocaml-migrate-parsetree gen_js_api.lib ppxlib.ast ppxlib)
  (kind ppx_rewriter)

--- a/ppx-test/dune
+++ b/ppx-test/dune
@@ -108,7 +108,7 @@
  (name test_library)
  (libraries ojs)
  (preprocess
-  (pps gen_js_api))
+  (pps gen_js_api.ppx))
  (modes byte)
  (modules binding_automatic binding_manual extension issues types))
 


### PR DESCRIPTION
This PR renames the ppx into "gen_js_api.ppx" and declares
"gen_js_api" as an alias of "ojs" library to retrieve
backward compatibility broken when we merged PR #120.