### PR TITLE
Make gen_js_api testable on older distributions

### DIFF
--- a/node-test/test1/dune
+++ b/node-test/test1/dune
@@ -9,4 +9,4 @@
 (rule
  (alias runtest)
  (action
-  (run node %{dep:./test.bc.js})))
+  (run nodejs %{dep:./test.bc.js})))


### PR DESCRIPTION
distributions such as Ubuntu 16.04 are old enough to not have the `node` binary but only `nodejs`