### PR TITLE
Add support for "newable" functions to [@@js.apply ]

### DIFF
--- a/VALUES.md
+++ b/VALUES.md
@@ -44,6 +44,15 @@ Supported forms
 
   The name of the function need not necessarily be `apply` as long as the `[@@js.apply]` attribute is present.
 
+  When the function you want to bind is a "newable" one (a function that must be called with a prefix `new`, e.g. constructors), add `as_constructor` to the payload. This is especially useful to bind to constructor interfaces in TypeScript.
+
+  ```ocaml
+  module FooConstructor: sig
+    type t
+    val new_: t -> Foo.t [@@js.apply as_constructor]
+  end
+  val fooConstructor: FooConstructor.t [@@js.global "Foo"]
+  ```
 
 - Object constructor:
 

--- a/VALUES.md
+++ b/VALUES.md
@@ -44,12 +44,12 @@ Supported forms
 
   The name of the function need not necessarily be `apply` as long as the `[@@js.apply]` attribute is present.
 
-  When the function you want to bind is a "newable" one (a function that must be called with a prefix `new`, e.g. constructors), add `as_constructor` to the payload. This is especially useful to bind to constructor interfaces in TypeScript.
+  When the function you want to bind is a "newable" one (a function that must be called with a prefix `new`, e.g. constructors), use `[@@js.apply_newable]` instead. This is especially useful to bind to constructor interfaces in TypeScript.
 
   ```ocaml
   module FooConstructor: sig
     type t
-    val new_: t -> Foo.t [@@js.apply as_constructor]
+    val new_: t -> Foo.t [@@js.apply_newable]
   end
   val fooConstructor: FooConstructor.t [@@js.global "Foo"]
   ```

--- a/node-test/test1/test.ml
+++ b/node-test/test1/test.ml
@@ -194,6 +194,40 @@ let () =
   assert (res1 = res2);
   ()
 
+(*** Newable function *)
+
+include [%js:
+  module Date: sig
+    type t = private Ojs.t
+    val getUTCFullYear: t -> float [@@js.call "getUTCFullYear"]
+    val getUTCMonth: t -> float [@@js.call "getUTCMonth"]
+    val getUTCDate: t -> float [@@js.call "getUTCDate"]
+  end
+
+  module DateConstructor: sig
+    type t = private Ojs.t
+    val utc:
+      t ->
+      year:int -> month:int -> ?date:int ->
+      ?hours:int -> ?minutes:int -> ?seconds:int ->
+      ?ms:int -> unit -> float [@@js.call "UTC"]
+    val new_:
+      t -> float -> Date.t [@@js.apply as_constructor]
+  end
+
+  val date: DateConstructor.t [@@js.global "Date"]
+]
+
+let () =
+  let d =
+    DateConstructor.new_ date
+      (DateConstructor.utc date ~year:1999 ~month:11 ~date:31 ())
+  in
+  assert (int_of_float (Date.getUTCFullYear d) == 1999);
+  assert (int_of_float (Date.getUTCMonth d) == 11);
+  assert (int_of_float (Date.getUTCDate d) == 31);
+  ()
+
 (** Arrays **)
 let () =
     let open Arrays.StringArray in

--- a/node-test/test1/test.ml
+++ b/node-test/test1/test.ml
@@ -212,7 +212,7 @@ include [%js:
       ?hours:int -> ?minutes:int -> ?seconds:int ->
       ?ms:int -> unit -> float [@@js.call "UTC"]
     val new_:
-      t -> float -> Date.t [@@js.apply_constructor]
+      t -> float -> Date.t [@@js.apply_newable]
   end
 
   val date: DateConstructor.t [@@js.global "Date"]

--- a/node-test/test1/test.ml
+++ b/node-test/test1/test.ml
@@ -212,7 +212,7 @@ include [%js:
       ?hours:int -> ?minutes:int -> ?seconds:int ->
       ?ms:int -> unit -> float [@@js.call "UTC"]
     val new_:
-      t -> float -> Date.t [@@js.apply as_constructor]
+      t -> float -> Date.t [@@js.apply_constructor]
   end
 
   val date: DateConstructor.t [@@js.global "Date"]

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -275,7 +275,7 @@ let arg_label = function
 
 type apply_type =
   | Function    (* f(..) *)
-  | Constructor (* new f(..) *)
+  | NewableFunction (* new f(..) *)
 
 type valdef =
   | Cast
@@ -300,7 +300,7 @@ let rec string_of_valdef = function
   | IndexSet -> "js.index_set"
   | MethCall _ -> "js.call"
   | Apply Function -> "js.apply"
-  | Apply Constructor -> "js.apply_constructor"
+  | Apply NewableFunction -> "js.apply_newable"
   | Global _ -> "js.global"
   | New None -> "js.create"
   | New (Some _) -> "js.new"
@@ -531,7 +531,7 @@ let parse_attr ~global_attrs (s, loc, auto) attribute =
       "js.index_set", (fun () -> IndexSet);
       "js.call", (fun () -> MethCall (opt_name ()));
       "js.apply", (fun () -> Apply Function);
-      "js.apply_constructor", (fun () -> Apply Constructor);
+      "js.apply_newable", (fun () -> Apply NewableFunction);
       "js.global", (fun () -> Global (opt_name ()));
       "js", (fun () -> auto ());
       "js.create", (fun () -> New None);
@@ -1635,7 +1635,7 @@ and gen_class_field x = function
             let res =
               match t with
               | Function -> ojs_apply_arr (var x) concrete_args
-              | Constructor -> ojs_new_obj_arr (var x) concrete_args
+              | NewableFunction -> ojs_new_obj_arr (var x) concrete_args
             in
             func formal_args unit_arg (js2ml_unit ty_res res)
         | _ -> error method_loc Binding_type_mismatch
@@ -1759,7 +1759,7 @@ and gen_def ~global_object loc decl ty =
       let res this =
         match t with
         | Function -> ojs_apply_arr (ml2js typ this) concrete_args
-        | Constructor -> ojs_new_obj_arr (ml2js typ this) concrete_args
+        | NewableFunction -> ojs_new_obj_arr (ml2js typ this) concrete_args
       in
       mkfun ~typ (fun this -> func formal_args unit_arg (js2ml_unit ty_res (res this)))
 


### PR DESCRIPTION
This PR extends `[@@js.apply]` so that it can be used to bind to "newable" (must be called with a prefix `new`) functions.

This will be useful when binding to "constructor interfaces" in TypeScript:

```typescript
interface FooConstructor {
  new () : Foo
}

declare var Foo: FooConstructor;
```

```ocaml
module FooConstructor: sig
  type t
  val new_: t -> Foo.t [@@js.apply as_constructor]
end

val foo: FooConstructor.t [@@js.global "Foo"]
```