### PR TITLE
Stop using OMP directly

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -16,6 +16,7 @@ jobs:
         node-version:
           - 14.x
         ocaml-version:
+          - 4.12.0
           - 4.11.1
           - 4.10.2
           - 4.09.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,10 @@ Changelog
 Upcoming
 --------
 
+- GPR#149: Stop using OMP directly (@mlasson)
 - GPR#143: Disable eta reduction for of_js and to_js of type aliases (@cannorin)
 - GPR#146: Fix an edge-case bug of prepare_args
+
 
 Version 1.0.7
 -------------

--- a/dune-project
+++ b/dune-project
@@ -35,7 +35,7 @@ gen_js_api is to be used with the js_of_ocaml compiler.
  (conflicts (js_of_ocaml-compiler (< 3.0.0)))
  (depends
   (ocaml (>= 4.08))
-  (ppxlib (>= 0.9))
+  (ppxlib (>= 0.22))
   (js_of_ocaml-compiler :with-test)
   (conf-npm :with-test)
   ojs))

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,6 @@ gen_js_api is to be used with the js_of_ocaml compiler.
  (depends
   (ocaml (>= 4.08))
   (ppxlib (>= 0.9))
-  (ocaml-migrate-parsetree (and (>= 1.6.0) (< 2.0.0)))
   (js_of_ocaml-compiler :with-test)
   (conf-npm :with-test)
   ojs))

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -23,7 +23,6 @@ depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08"}
   "ppxlib" {>= "0.9"}
-  "ocaml-migrate-parsetree" {>= "1.6.0" & < "2.0.0"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs"

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.0"}
   "ocaml" {>= "4.08"}
-  "ppxlib" {>= "0.9"}
+  "ppxlib" {>= "0.22"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs"

--- a/ppx-driver/dune
+++ b/ppx-driver/dune
@@ -2,7 +2,7 @@
  (name gen_js_api_ppx_driver)
  (public_name gen_js_api.ppx)
  (synopsis "Syntactic support for gen_js_api")
- (libraries ocaml-migrate-parsetree gen_js_api.lib ppxlib.ast ppxlib)
+ (libraries gen_js_api.lib ppxlib.ast ppxlib)
  (kind ppx_rewriter)
  (ppx_runtime_libraries ojs)
  (preprocess no_preprocessing))

--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -11,8 +11,6 @@ let () =
   then (
     Ppxlib.Driver.enable_location_check ()
   );
-  Gen_js_api_ppx.mark_as_handled_manually := (fun attribute ->
-      Ppxlib.Attribute.mark_as_handled_manually attribute);
   let mapper_for_sig =
     Gen_js_api_ppx.mark_attributes_as_used
   in

--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -47,7 +47,6 @@ let () =
   Gen_js_api_ppx.mark_as_handled_manually := (fun attribute ->
       Ppxlib.Attribute.mark_as_handled_manually attribute);
   let mapper_for_sig =
-
     Gen_js_api_ppx.mark_attributes_as_used
   in
   let mapper_for_str =
@@ -55,10 +54,7 @@ let () =
   in
   let module_expr_ext =
     let rewriter ~loc ~path:_ si =
-      si
-
-      |> Gen_js_api_ppx.module_expr_rewriter ~loc ~attrs:[]
-
+      Gen_js_api_ppx.module_expr_rewriter ~loc ~attrs:[] si
     in
     Ppxlib.Extension.declare "js"
       Ppxlib.Extension.Context.Module_expr
@@ -68,8 +64,7 @@ let () =
   in
   let ext_to =
     let rewriter ~loc ~path:_ core_type =
-      core_type
-      |> Gen_js_api_ppx.js_to_rewriter ~loc
+      Gen_js_api_ppx.js_to_rewriter ~loc core_type
     in
     Ppxlib.Extension.declare "js.to"
       Ppxlib.Extension.Context.Expression
@@ -79,8 +74,7 @@ let () =
   in
   let ext_of =
     let rewriter ~loc ~path:_ core_type =
-      core_type
-      |> Gen_js_api_ppx.js_of_rewriter ~loc
+      Gen_js_api_ppx.js_of_rewriter ~loc core_type
     in
     Ppxlib.Extension.declare "js.of"
       Ppxlib.Extension.Context.Expression
@@ -90,10 +84,9 @@ let () =
   in
   let attr_typ =
     let rewriter ~ctxt (rec_flag : Ppxlib.Asttypes.rec_flag) tdl _ =
-      tdl
-      |> Gen_js_api_ppx.type_decl_rewriter
+      Gen_js_api_ppx.type_decl_rewriter
         ~loc:(Ppxlib.Expansion_context.Deriver.derived_item_loc ctxt)
-        rec_flag
+        rec_flag tdl
     in
     Ppxlib.Context_free.Rule.attr_str_type_decl
       (Ppxlib.Attribute.declare "js"

--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -1,36 +1,3 @@
-(*
-module From_ppx = Migrate_parsetree.OCaml_411
-module Selected =  Ppxlib.Select_ast(From_ppx)
-
-module Of_ppxlib = struct
-  include Selected.To_ocaml
-  let copy_rec_flag (rec_flag : Ppxlib.Asttypes.rec_flag) : From_ppx.Ast.Asttypes.rec_flag =
-    match rec_flag with
-    | Nonrecursive -> From_ppx.Ast.Asttypes.Nonrecursive
-    | Recursive -> Recursive
-end
-
-module To_ppxlib = struct
-  include Selected.Of_ocaml
-
-  let copy_module_expr (m : From_ppx.Ast.Parsetree.module_expr) : Ppxlib.Parsetree.module_expr =
-    match
-      copy_structure
-        [ From_ppx.Ast.Ast_helper.(Str.module_ (Mb.mk ({txt= Some "FAKE";loc=Location.none}) m))]
-    with
-    | [{pstr_desc=Pstr_module {pmb_expr;_}; _}] -> pmb_expr
-    | _ -> assert false
-
-  let copy_attribute (a : From_ppx.Ast.Parsetree.attribute)
-  : Ppxlib.Ast.attribute =
-  let pat : Migrate_parsetree.Ast_411.Parsetree.pattern =
-    Migrate_parsetree.Ast_411.Ast_helper.Pat.any ~attrs:[a] ()
-  in
-  let pat = copy_pattern pat in
-  List.hd pat.ppat_attributes
-end *)
-
-
 let check_attributes_with_ppxlib = false
 let check_locations_with_ppxlib = false
 

--- a/ppx-driver/gen_js_api_ppx_driver.ml
+++ b/ppx-driver/gen_js_api_ppx_driver.ml
@@ -17,7 +17,7 @@ let () =
     Gen_js_api_ppx.mark_attributes_as_used
   in
   let mapper_for_str =
-      Gen_js_api_ppx.mark_attributes_as_used
+    Gen_js_api_ppx.mark_attributes_as_used
   in
   let module_expr_ext =
     let rewriter ~loc ~path:_ si =

--- a/ppx-lib/dune
+++ b/ppx-lib/dune
@@ -1,6 +1,6 @@
 (library
  (name gen_js_api_ppx)
  (public_name gen_js_api.lib)
- (libraries compiler-libs.common ocaml-migrate-parsetree)
+ (libraries compiler-libs.common ppxlib)
  (ppx_runtime_libraries ojs)
  (preprocess no_preprocessing))

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -126,7 +126,7 @@ let get_string_attribute_default key default attrs =
   | None -> default
   | Some payload -> payload.attr_loc, id_of_expr (expr_of_payload payload)
 
-let _print_error ppf = function
+let print_error ppf = function
   | Expression_expected ->
       Format.fprintf ppf "Expression expected"
   | Structure_expected ->
@@ -181,7 +181,12 @@ let _print_error ppf = function
 let () =
   Location.Error.register_error_of_exn
     (function
-      | Error (loc, _err) -> Some (Location.Error.make  ~loc ~sub:[] "ERROR")
+      | Error (loc, err) ->
+        let createf ~loc fmt =
+          Format.kasprintf
+            (fun str -> Location.Error.make ~loc ~sub:[] str) fmt
+        in
+        Some (createf ~loc "%a" print_error err)
       | _ -> None
     )
 

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -55,7 +55,6 @@ let is_ascii s =
   with Break -> false
 
 let check_attribute = ref true
-let mark_as_handled_manually = ref (fun (_ : Parsetree.attribute) -> ())
 let used_attributes_tbl = Hashtbl.create 16
 
 (* [merlin_hide] tells merlin to not look at a node, or at any of its
@@ -67,7 +66,7 @@ let merlin_hide =
   }
 
 let register_loc attr =
-  !mark_as_handled_manually attr;
+  Ppxlib.Attribute.mark_as_handled_manually attr;
   Hashtbl.replace used_attributes_tbl attr.attr_name.loc ()
 
 let is_registered_loc loc = Hashtbl.mem used_attributes_tbl loc

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -2,13 +2,19 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
-open Migrate_parsetree.Ast_411
+open Ppxlib
 
-open Location
 open Asttypes
 open Parsetree
 open Longident
-open! Ast_helper
+open Ast_helper
+open Location
+
+let mkloc txt loc =
+  { txt; loc }
+
+let mknoloc txt =
+  mkloc txt !Ast_helper.default_loc
 
 (** Errors *)
 
@@ -120,7 +126,7 @@ let get_string_attribute_default key default attrs =
   | None -> default
   | Some payload -> payload.attr_loc, id_of_expr (expr_of_payload payload)
 
-let print_error ppf = function
+let _print_error ppf = function
   | Expression_expected ->
       Format.fprintf ppf "Expression expected"
   | Structure_expected ->
@@ -173,9 +179,9 @@ let print_error ppf = function
       Format.fprintf ppf "Record %s expected." shape
 
 let () =
-  Location.register_error_of_exn
+  Location.Error.register_error_of_exn
     (function
-      | Error (loc, err) -> Some (Location.error_of_printer ~loc print_error err)
+      | Error (loc, _err) -> Some (Location.Error.make  ~loc ~sub:[] "ERROR")
       | _ -> None
     )
 
@@ -308,7 +314,7 @@ let auto_deprecation_attribute loc valdef =
       "Heuristic for automatic binding is deprecated; please add the '@%s' attribute."
       (string_of_valdef valdef)
   in
-  Ast_mapper.attribute_of_warning loc message
+  attribute_of_warning loc message
 
 type methoddef =
   | Getter of string
@@ -394,7 +400,7 @@ and parse_typ ~variance ctx ~global_attrs ty =
           end
       end
   | Ptyp_constr ({txt = lid; loc = _}, tl) ->
-      begin match String.concat "." (Longident.flatten lid), tl with
+      begin match String.concat "." (Longident.flatten_exn lid), tl with
       | "unit", [] -> Unit ty.ptyp_loc
       | "Ojs.t", [] -> Js
       | s, tl -> Name (s, List.map (parse_typ ~variance ctx ~global_attrs) tl)
@@ -855,15 +861,16 @@ let ojs_new_obj_arr cl = function
 let assert_false = Exp.assert_ (Exp.construct (mknoloc (longident_parse "false")) None)
 
 let clear_attr_mapper =
-  let mapper = Ast_mapper.default_mapper in
-  let attributes _this attrs =
+  object
+  inherit Ast_traverse.map
+
+  method! attributes attrs =
     let f {attr_name = {txt = _; loc}; _} = not (is_registered_loc loc) in
     List.filter f attrs
-  in
-  { mapper with Ast_mapper.attributes }
+  end
 
 let rewrite_typ_decl t =
-  let t = clear_attr_mapper.type_declaration clear_attr_mapper {t with ptype_private = Public} in
+  let t = clear_attr_mapper # type_declaration {t with ptype_private = Public} in
   match t.ptype_manifest, t.ptype_kind with
   | None, Ptype_abstract -> {t with ptype_manifest = Some ojs_typ}
   | _ -> t
@@ -1339,7 +1346,7 @@ and gen_typ = function
       List.fold_right (fun {lab; att=_; typ} t2 -> Typ.arrow (arg_label lab) (gen_typ typ) t2) tl (gen_typ ty_res)
   | Variant {location = _; global_attrs = _; attributes = _; constrs} ->
       let f {mlconstr; arg; attributes = _; location = _} =
-        let mlconstr = Location.mknoloc mlconstr in
+        let mlconstr = mknoloc mlconstr in
         match arg with
         | Constant -> Rf.mk (Rtag (mlconstr, true, []))
         | Unary typ -> Rf.mk (Rtag (mlconstr, false, [gen_typ typ]))
@@ -1398,9 +1405,9 @@ and gen_funs ~global_attrs p =
   let global_attrs = global_attrs in
   let ctx_withloc =
     List.map (function
-        | {ptyp_desc = Ptyp_any; ptyp_loc = loc; ptyp_attributes = _; ptyp_loc_stack = _}, Invariant ->
+        | {ptyp_desc = Ptyp_any; ptyp_loc = loc; ptyp_attributes = _; ptyp_loc_stack = _}, (NoVariance, _) ->
             { loc = loc; txt = fresh () }
-        | {ptyp_desc = Ptyp_var label; ptyp_loc = loc; ptyp_attributes = _; ptyp_loc_stack = _}, Invariant ->
+        | {ptyp_desc = Ptyp_var label; ptyp_loc = loc; ptyp_attributes = _; ptyp_loc_stack = _}, (NoVariance, _) ->
             { loc = loc; txt = label }
         | _ -> error p.ptype_loc Cannot_parse_type
       ) p.ptype_params
@@ -1568,7 +1575,7 @@ and gen_decl = function
       [Str.class_ classes; Str.value Nonrecursive cast_funcs]
 
   | Implem str ->
-      mapper.Ast_mapper.structure mapper str
+      (Lazy.force mapper) # structure str
 
   | Open descr ->
       let descr = {descr with popen_expr = Mod.ident descr.popen_expr} in
@@ -1802,7 +1809,7 @@ and module_expr_rewriter ~loc ~attrs sg =
   let str = str_of_sg ~global_attrs:attrs sg in
   Mod.constraint_
     (Mod.structure ~attrs:[ merlin_hide ] str)
-    (Mty.signature ~loc ~attrs (clear_attr_mapper.signature clear_attr_mapper sg))
+    (Mty.signature ~loc ~attrs (clear_attr_mapper # signature sg))
 
 and js_to_rewriter ~loc ty =
   let e' = with_default_loc {loc with loc_ghost = true }
@@ -1829,18 +1836,18 @@ and type_decl_rewriter ~loc rec_flag l =
   itm
 
 and mapper =
-  let open Ast_mapper in
-  let super = default_mapper in
+  lazy (object
+    inherit Ast_traverse.map as super
 
-  let module_expr self mexp =
-    let mexp = super.module_expr self mexp in
+  method! module_expr mexp =
+    let mexp = super # module_expr mexp in
     match mexp.pmod_desc with
     | Pmod_extension ({txt = "js"; _}, PSig sg) ->
         module_expr_rewriter ~loc:mexp.pmod_loc ~attrs:mexp.pmod_attributes sg
     | _ -> mexp
-  in
-  let structure_item self str =
-    let str = super.structure_item self str in
+
+  method! structure_item str =
+    let str = super # structure_item str in
     let global_attrs = [] in
     match str.pstr_desc with
     | Pstr_primitive vd when vd.pval_prim = [] ->
@@ -1861,9 +1868,9 @@ and mapper =
         end
     | _ ->
         str
-  in
-  let expr self e =
-    let e = super.expr self e in
+
+    method! expression e =
+    let e = super # expression e in
     match e.pexp_desc with
     | Pexp_extension (attr, PTyp ty) when filter_extension "js.to" attr ->
         js_to_rewriter ~loc:e.pexp_loc ty
@@ -1871,25 +1878,27 @@ and mapper =
         js_of_rewriter ~loc:e.pexp_loc ty
     | _ ->
         e
-  in
-  let attribute self a =
+
+  method! attribute a =
     ignore (filter_attr_name "js.dummy" a : bool);
-    super.attribute self a
-  in
-  {super with module_expr; structure_item; expr; attribute}
+    super # attribute a
+
+  end)
 
 let is_js_attribute txt = txt = "js" || has_prefix ~prefix:"js." txt
 
 let check_loc_mapper =
-  let mapper = Ast_mapper.default_mapper in
-  let attribute _this ({attr_name = {txt; loc}; _} as attr) =
+  object
+    inherit Ast_traverse.map
+
+   method! attribute ({attr_name = {txt; loc}; _} as attr) =
     if is_js_attribute txt then begin
       if is_registered_loc loc || not !check_attribute then ()
       else error loc Spurious_attribute
     end;
     attr
-  in
-  { mapper with Ast_mapper.attribute }
+
+  end
 
 (** Main *)
 
@@ -1901,14 +1910,6 @@ let specs =
   ]
 
 let usage = "gen_js_api [-o mymodule.ml] mymodule.mli"
-
-let from_current =
-  let open Migrate_parsetree in
-  Versions.migrate Versions.ocaml_current Versions.ocaml_411
-
-let to_current =
-  let open Migrate_parsetree in
-  Versions.migrate Versions.ocaml_411 Versions.ocaml_current
 
 let standalone () =
   let files = ref [] in
@@ -1922,31 +1923,32 @@ let standalone () =
   if !out = "" then out := Filename.chop_extension src ^ ".ml";
   let oc = if !out = "-" then stdout else open_out !out in
   let sg =
-    Pparse.parse_interface
+    Ocaml_common.Pparse.parse_interface
       ~tool_name:"gen_js_iface"
-      src |> from_current.Migrate_parsetree.Versions.copy_signature
+      src |> Selected_ast.Of_ocaml.copy_signature
   in
   let str = str_of_sg ~global_attrs:[] sg in
-  ignore (check_loc_mapper.Ast_mapper.signature check_loc_mapper sg);
-  let str = clear_attr_mapper.Ast_mapper.structure clear_attr_mapper str in
-  Format.fprintf (Format.formatter_of_out_channel oc) "%a@." Pprintast.structure (to_current.copy_structure str);
+  ignore (check_loc_mapper # signature sg);
+  let str = clear_attr_mapper # structure str in
+  Format.fprintf (Format.formatter_of_out_channel oc) "%a@." Pprintast.structure str;
   if !out <> "-" then close_out oc
 
-
 let mapper =
-  { mapper with
-    Ast_mapper.structure = (fun _this str ->
-        check_loc_mapper.Ast_mapper.structure
-          check_loc_mapper
-          (mapper.Ast_mapper.structure mapper str));
-  }
+  object
+    inherit Ast_traverse.map as super
 
-let mark_attributes_as_used mapper =
+    method! structure str =
+      check_loc_mapper # structure (super#structure str)
+  end
+
+
+let mark_attributes_as_used =
   (* mark `js.***` attributes as used in mli. *)
-  let attribute : _ -> attribute -> _ =
-    fun this ({attr_name = {txt; _}; _} as attr) ->
+  object
+    inherit Ast_traverse.map as super
+    method! attribute ({attr_name = {txt; _}; _} as attr) =
       if is_js_attribute txt then
         ignore (filter_attr_name txt attr : bool);
-      mapper.Ast_mapper.attribute this attr
-  in
-  { mapper with attribute }
+
+      super # attribute attr
+  end

--- a/ppx-lib/gen_js_api_ppx.mli
+++ b/ppx-lib/gen_js_api_ppx.mli
@@ -4,8 +4,6 @@
 
 open Ppxlib
 
-val mark_as_handled_manually : (Parsetree.attribute -> unit) ref
-
 val check_attribute : bool ref
 
 val mapper : Ast_traverse.map

--- a/ppx-lib/gen_js_api_ppx.mli
+++ b/ppx-lib/gen_js_api_ppx.mli
@@ -2,36 +2,22 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
-val mark_as_handled_manually : (Migrate_parsetree.Ast_411.Parsetree.attribute -> unit) ref
+open Ppxlib
+
+val mark_as_handled_manually : (Parsetree.attribute -> unit) ref
 
 val check_attribute : bool ref
 
-val mapper : Migrate_parsetree.Ast_411.Ast_mapper.mapper
+val mapper : Ast_traverse.map
 
-val module_expr_rewriter
-  :  loc:Location.t
-  -> attrs:Migrate_parsetree.Ast_411.Parsetree.attributes
-  -> Migrate_parsetree.Ast_411.Parsetree.signature
-  -> Migrate_parsetree.Ast_411.Parsetree.module_expr
+val module_expr_rewriter: loc:Location.t -> attrs:Ppxlib.Parsetree.attributes -> Ppxlib.Parsetree.signature -> Ppxlib.module_expr
 
-val js_of_rewriter
-  :  loc:Location.t
-  -> Migrate_parsetree.Ast_411.Parsetree.core_type
-  -> Migrate_parsetree.Ast_411.Parsetree.expression
+val js_of_rewriter: loc:Location.t -> core_type -> expression
 
-val js_to_rewriter
-  :  loc:Location.t
-  -> Migrate_parsetree.Ast_411.Parsetree.core_type
-  -> Migrate_parsetree.Ast_411.Parsetree.expression
+val js_to_rewriter: loc:Location.t -> core_type -> expression
 
-val type_decl_rewriter
-  :  loc:Location.t
-  -> Migrate_parsetree.Ast_411.Asttypes.rec_flag
-  -> Migrate_parsetree.Ast_411.Parsetree.type_declaration list
-  -> Migrate_parsetree.Ast_411.Parsetree.structure
+val type_decl_rewriter: loc:Location.t -> rec_flag -> type_declaration list -> structure
 
-val mark_attributes_as_used
-  :  Migrate_parsetree.Ast_411.Ast_mapper.mapper
-  -> Migrate_parsetree.Ast_411.Ast_mapper.mapper
+val mark_attributes_as_used: Ast_traverse.map
 
 val standalone : unit -> unit

--- a/ppx-standalone/dune
+++ b/ppx-standalone/dune
@@ -2,7 +2,7 @@
  (names gen_js_api)
  (public_names gen_js_api)
  (package gen_js_api)
- (libraries compiler-libs.common ocaml-migrate-parsetree gen_js_api.lib))
+ (libraries compiler-libs.common ppxlib gen_js_api.lib))
 
 (install
  (section libexec)

--- a/ppx-standalone/gen_js_api.ml
+++ b/ppx-standalone/gen_js_api.ml
@@ -2,13 +2,11 @@
 (* See the attached LICENSE file.                                         *)
 (* Copyright 2015 by LexiFi.                                              *)
 
-open Migrate_parsetree.Ast_411
+open Ppxlib
 
 let () =
   try
-    if Array.length Sys.argv < 4 || Sys.argv.(1) <> "-ppx" then Gen_js_api_ppx.standalone ()
-    else
-      Ast_mapper.run_main (fun _ -> Gen_js_api_ppx.mapper)
+    Gen_js_api_ppx.standalone ()
   with exn ->
     Format.eprintf "%a@." Location.report_exception exn;
     exit 2

--- a/ppx-test/dune
+++ b/ppx-test/dune
@@ -19,7 +19,8 @@
 (rule
  (alias runtest)
  (package gen_js_api)
- (enabled_if (>= %{ocaml_version} 4.09))
+ (enabled_if
+  (>= %{ocaml_version} 4.09))
  (action
   (diff expected/issues.ml issues.ml.result)))
 
@@ -32,7 +33,8 @@
 (rule
  (alias runtest)
  (package gen_js_api)
- (enabled_if (>= %{ocaml_version} 4.09))
+ (enabled_if
+  (>= %{ocaml_version} 4.09))
  (action
   (diff expected/types.ml types.ml.result)))
 

--- a/ppx-test/expected/issues.ml
+++ b/ppx-test/expected/issues.ml
@@ -55,12 +55,11 @@ module Issue124 :
       and b_of_js : Ojs.t -> b = fun js -> { a = (a_of_js js) }
       and b_to_js : b -> Ojs.t = fun { a } -> a_to_js a
       type 'a dummy = Ojs.t
-      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy =
-        fun (type __a) ->
-          fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
-      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t =
-        fun (type __a) ->
-          fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
+      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy = fun
+        (type __a) ->
+        fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
+      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t = fun (type
+        __a) -> fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
       type 'a wrapped =
         | Wrapped of 'a 
       let rec wrapped_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a wrapped =

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -408,47 +408,42 @@ module T :
       let rec parametrized_of_js :
         'a 'b .
           (Ojs.t -> 'a) -> (Ojs.t -> 'b) -> Ojs.t -> ('a, 'b) parametrized
-        =
-        fun (type __a) ->
-          fun (type __b) ->
-            fun (__a_of_js : Ojs.t -> __a) ->
-              fun (__b_of_js : Ojs.t -> __b) ->
-                fun (x130 : Ojs.t) ->
-                  {
-                    x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
-                    y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
-                  }
+        = fun (type __a) -> fun (type __b) ->
+        fun (__a_of_js : Ojs.t -> __a) ->
+          fun (__b_of_js : Ojs.t -> __b) ->
+            fun (x130 : Ojs.t) ->
+              {
+                x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
+                y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
+              }
       and parametrized_to_js :
         'a 'b .
           ('a -> Ojs.t) -> ('b -> Ojs.t) -> ('a, 'b) parametrized -> Ojs.t
-        =
-        fun (type __a) ->
-          fun (type __b) ->
-            fun (__a_to_js : __a -> Ojs.t) ->
-              fun (__b_to_js : __b -> Ojs.t) ->
-                fun (x129 : (__a, __b) parametrized) ->
-                  Ojs.obj
-                    [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
+        = fun (type __a) -> fun (type __b) ->
+        fun (__a_to_js : __a -> Ojs.t) ->
+          fun (__b_to_js : __b -> Ojs.t) ->
+            fun (x129 : (__a, __b) parametrized) ->
+              Ojs.obj [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
       type 'a abs = ('a -> int) -> unit
-      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs =
-        fun (type __a) ->
-          fun (__a_of_js : Ojs.t -> __a) ->
-            fun (x134 : Ojs.t) ->
-              fun (x135 : __a -> int) ->
-                ignore
-                  (Ojs.apply x134
-                     [|(Ojs.fun_to_js 1
-                          (fun (x136 : Ojs.t) ->
-                             Ojs.int_to_js (x135 (__a_of_js x136))))|])
-      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t =
-        fun (type __a) ->
-          fun (__a_to_js : __a -> Ojs.t) ->
-            fun (x131 : (__a -> int) -> unit) ->
-              Ojs.fun_to_js 1
-                (fun (x132 : Ojs.t) ->
-                   x131
-                     (fun (x133 : __a) ->
-                        Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
+      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs = fun (type
+        __a) ->
+        fun (__a_of_js : Ojs.t -> __a) ->
+          fun (x134 : Ojs.t) ->
+            fun (x135 : __a -> int) ->
+              ignore
+                (Ojs.apply x134
+                   [|(Ojs.fun_to_js 1
+                        (fun (x136 : Ojs.t) ->
+                           Ojs.int_to_js (x135 (__a_of_js x136))))|])
+      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t = fun (type __a)
+        ->
+        fun (__a_to_js : __a -> Ojs.t) ->
+          fun (x131 : (__a -> int) -> unit) ->
+            Ojs.fun_to_js 1
+              (fun (x132 : Ojs.t) ->
+                 x131
+                   (fun (x133 : __a) ->
+                      Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
       type specialized = (int, int) parametrized
       let rec specialized_of_js : Ojs.t -> specialized =
         fun (x140 : Ojs.t) ->

--- a/ppx-test/ppx/dune
+++ b/ppx-test/ppx/dune
@@ -1,3 +1,3 @@
 (executable
  (name main)
- (libraries ocaml-migrate-parsetree gen_js_api_ppx_driver))
+ (libraries ppxlib gen_js_api_ppx_driver))

--- a/ppx-test/ppx/main.ml
+++ b/ppx-test/ppx/main.ml
@@ -1,4 +1,3 @@
-open Migrate_parsetree
 
 (* To run as a standalone binary, run the registered drivers *)
-let () = Driver.run_main ()
+let () = Ppxlib.Driver.standalone ()


### PR DESCRIPTION
# Description

Let's stop using OMP directly and use the more idiomatic interfaces of Ppxlib. 
This allows to drop the conflict with newer version of OMP. 

