### PR TITLE
Add support for float enum & float union discriminator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,13 @@
 Changelog
 =========
 
-Upcoming
---------
+Version 1.0.9
+-------------
 
-- GPR#153: Support recursive modulesa (@cannorin)
-- GPR#153: [@@js.invoke] attribute to call the global object as a function (@cannorin)
+- GPR#161: Fix broken link to VALUES.md (@joelburget)
+- GPR#154: Upgrade to ocaml/setup-ocaml@v2 (@smorimoto)
+- GPR#153: Support recursive modules (@cannorin)
+- GPR#152: [@@js.invoke] attribute to call the global object as a function (@cannorin)
 
 Version 1.0.8
 -------------

--- a/TYPES.md
+++ b/TYPES.md
@@ -232,32 +232,35 @@ constructors) can be used to bind to "enums" in JavaScript.  By
 default, constructors are mapped to the JS string equal to their OCaml
 name, but a custom translation can be provided with a `[@js]`
 attribute.  This custom translation can be a string or an integer
-literal.
+literal or a float literal.
 
 ```ocaml
 type t =
   | Foo [@js "foo"]
   | Bar [@js 42]
-  | Baz
+  | Baz [@js 4.2]
+  | Qux
     [@@js.enum]
 
-type t = [`foo | `bar [@js 42] | `Baz] [@@js.enum]
+type t = [`foo | `bar [@js 42] | `baz [@js 4.2] | `Qux] [@@js.enum]
 ```
 
 
 It is possible to specify constructors with one argument of
-type either int or string, used to represent "all other cases" of JS values.
+type (int or float or string), used to represent "all other cases" of JS values.
 
 ```ocaml
 type status =
   | OK [@js 1]
   | KO [@js 2]
+  | OO [@js 1.5]
   | OtherS of string [@js.default]
   | OtherI of int [@js.default]
     [@@js.enum]
 ```
 
 There cannot be two default constructors with the same argument type.
+Also, there cannot be default constructors of type int and float at the same time.
 
 Sum types mapped to records with a discriminator field
 ------------------------------------------------------
@@ -390,7 +393,7 @@ This generalisation of the `[@js.enum]` attribute can only be used on
 polymorphic variant used in contravariant context (i.e. to describe
 mapping from OCaml to JavaScript, not the other way around).  With
 this calling convention, first the representation of the constructor
-(which can be either an integer or a string, which is derived
+(which can be an integer or a float or a string, which is derived
 automatically if not specified with a `[@js]` attribute) is passed,
 followed by the n arguments of the constructor.
 

--- a/ppx-test/expected/issues.ml
+++ b/ppx-test/expected/issues.ml
@@ -75,6 +75,7 @@ module Issue124 :
         fun (x15 : Ojs.t) ->
           let x16 = x15 in
           match Ojs.type_of (Ojs.get_prop_ascii x16 "type") with
+          | "number" -> Unknown x16
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x16 "type") with
                | "t" -> T (t_of_js x16)

--- a/ppx-test/expected/issues.ml
+++ b/ppx-test/expected/issues.ml
@@ -75,17 +75,12 @@ module Issue124 :
         fun (x15 : Ojs.t) ->
           let x16 = x15 in
           match Ojs.type_of (Ojs.get_prop_ascii x16 "type") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x16 "type") with
-               | _ -> Unknown x16)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x16 "type") with
                | "t" -> T (t_of_js x16)
                | "wrapped_t" -> WrappedT (wrapped_of_js t_of_js x16)
                | _ -> Unknown x16)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x16 "type") with
-               | _ -> Unknown x16)
+          | "boolean" -> Unknown x16
           | _ -> Unknown x16
       and u_to_js : u -> Ojs.t =
         fun (x10 : u) ->

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -313,7 +313,7 @@ module T :
       | OO 
       | OtherS of string 
       | OtherI of int 
-    type poly = [ `foo  | `bar  | `Baz  | `I of int  | `S of string ]
+    type poly = [ `foo  | `bar  | `baz  | `Qux  | `I of int  | `S of string ]
     type sum =
       | A 
       | B of int 
@@ -511,25 +511,35 @@ module T :
           | OO -> Ojs.float_to_js 1.5
           | OtherS x147 -> Ojs.string_to_js x147
           | OtherI x148 -> Ojs.int_to_js x148
-      type poly = [ `foo  | `bar  | `Baz  | `I of int  | `S of string ]
+      type poly =
+        [ `foo  | `bar  | `baz  | `Qux  | `I of int  | `S of string ]
       let rec poly_of_js : Ojs.t -> poly =
         fun (x156 : Ojs.t) ->
           let x157 = x156 in
           match Ojs.type_of x157 with
           | "number" ->
-              (match Ojs.int_of_js x157 with | 42 -> `bar | x158 -> `I x158)
+              (match Ojs.float_of_js x157 with
+               | 4.2 -> `baz
+               | _ ->
+                   (match Ojs.int_of_js x157 with
+                    | 42 -> `bar
+                    | x158 -> `I x158))
           | "string" ->
               (match Ojs.string_of_js x157 with
                | "foo" -> `foo
-               | "Baz" -> `Baz
+               | "Qux" -> `Qux
                | x159 -> `S x159)
           | _ -> assert false
       and poly_to_js : poly -> Ojs.t =
-        fun (x153 : [ `foo  | `bar  | `Baz  | `I of int  | `S of string ]) ->
+        fun
+          (x153 :
+            [ `foo  | `bar  | `baz  | `Qux  | `I of int  | `S of string ])
+          ->
           match x153 with
           | `foo -> Ojs.string_to_js "foo"
           | `bar -> Ojs.int_to_js 42
-          | `Baz -> Ojs.string_to_js "Baz"
+          | `baz -> Ojs.float_to_js 4.2
+          | `Qux -> Ojs.string_to_js "Qux"
           | `I x154 -> Ojs.int_to_js x154
           | `S x155 -> Ojs.string_to_js x155
       type sum =

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -306,9 +306,11 @@ module T :
       | Foo 
       | Bar 
       | Baz 
+      | Qux 
     type status =
       | OK 
       | KO 
+      | OO 
       | OtherS of string 
       | OtherI of int 
     type poly = [ `foo  | `bar  | `Baz  | `I of int  | `S of string ]
@@ -455,16 +457,22 @@ module T :
         | Foo 
         | Bar 
         | Baz 
+        | Qux 
       let rec enum_of_js : Ojs.t -> enum =
         fun (x144 : Ojs.t) ->
           let x145 = x144 in
           match Ojs.type_of x145 with
           | "number" ->
-              (match Ojs.int_of_js x145 with | 42 -> Bar | _ -> assert false)
+              (match Ojs.int_of_js x145 with
+               | 42 -> Bar
+               | _ ->
+                   (match Ojs.float_of_js x145 with
+                    | 4.2 -> Baz
+                    | _ -> assert false))
           | "string" ->
               (match Ojs.string_of_js x145 with
                | "foo" -> Foo
-               | "Baz" -> Baz
+               | "Qux" -> Qux
                | _ -> assert false)
           | _ -> assert false
       and enum_to_js : enum -> Ojs.t =
@@ -472,10 +480,12 @@ module T :
           match x143 with
           | Foo -> Ojs.string_to_js "foo"
           | Bar -> Ojs.int_to_js 42
-          | Baz -> Ojs.string_to_js "Baz"
+          | Baz -> Ojs.float_to_js 4.2
+          | Qux -> Ojs.string_to_js "Qux"
       type status =
         | OK 
         | KO 
+        | OO 
         | OtherS of string 
         | OtherI of int 
       let rec status_of_js : Ojs.t -> status =
@@ -483,10 +493,13 @@ module T :
           let x150 = x149 in
           match Ojs.type_of x150 with
           | "number" ->
-              (match Ojs.int_of_js x150 with
-               | 1 -> OK
-               | 2 -> KO
-               | x152 -> OtherI x152)
+              (match Ojs.float_of_js x150 with
+               | 1.5 -> OO
+               | _ ->
+                   (match Ojs.int_of_js x150 with
+                    | 1 -> OK
+                    | 2 -> KO
+                    | x152 -> OtherI x152))
           | "string" ->
               (match Ojs.string_of_js x150 with | x151 -> OtherS x151)
           | _ -> assert false
@@ -495,6 +508,7 @@ module T :
           match x146 with
           | OK -> Ojs.int_to_js 1
           | KO -> Ojs.int_to_js 2
+          | OO -> Ojs.float_to_js 1.5
           | OtherS x147 -> Ojs.string_to_js x147
           | OtherI x148 -> Ojs.int_to_js x148
       type poly = [ `foo  | `bar  | `Baz  | `I of int  | `S of string ]
@@ -530,9 +544,6 @@ module T :
         fun (x167 : Ojs.t) ->
           let x168 = x167 in
           match Ojs.type_of (Ojs.get_prop_ascii x168 "kind") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x168 "kind") with
-               | _ -> Unknown x168)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x168 "kind") with
                | "A" -> A
@@ -551,9 +562,7 @@ module T :
                          (Ojs.string_of_js (Ojs.get_prop_ascii x168 "name"))
                      }
                | _ -> Unknown x168)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x168 "kind") with
-               | _ -> Unknown x168)
+          | "boolean" -> Unknown x168
           | _ -> Unknown x168
       and sum_to_js : sum -> Ojs.t =
         fun (x160 : sum) ->
@@ -589,9 +598,6 @@ module T :
         fun (x177 : Ojs.t) ->
           let x178 = x177 in
           match Ojs.type_of (Ojs.get_prop_ascii x178 "kind") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x178 "kind") with
-               | _ -> Unknown x178)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x178 "kind") with
                | "A" -> A
@@ -611,9 +617,7 @@ module T :
                      }
                | "F" -> E (Ojs.int_of_js (Ojs.get_prop_ascii x178 "fArg"))
                | _ -> Unknown x178)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x178 "kind") with
-               | _ -> Unknown x178)
+          | "boolean" -> Unknown x178
           | _ -> Unknown x178
       and t_to_js : t -> Ojs.t =
         fun (x169 : t) ->
@@ -669,18 +673,13 @@ module T :
         fun (x195 : Ojs.t) ->
           let x196 = x195 in
           match Ojs.type_of (Ojs.get_prop_ascii x196 "discr") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x196 "discr") with
-               | _ -> D x196)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x196 "discr") with
                | "A" -> A
                | "B" -> B (Ojs.int_of_js x196)
                | "C" -> C (Ojs.int_of_js x196)
                | _ -> D x196)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x196 "discr") with
-               | _ -> D x196)
+          | "boolean" -> D x196
           | _ -> D x196
       and discr_union_to_js : discr_union -> Ojs.t =
         fun (x191 : discr_union) ->
@@ -694,18 +693,13 @@ module T :
         fun (x201 : Ojs.t) ->
           let x202 = x201 in
           match Ojs.type_of (Ojs.get_prop_ascii x202 "discr") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x202 "discr") with
-               | _ -> `D x202)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x202 "discr") with
                | "A" -> `A
                | "B" -> `B (Ojs.int_of_js x202)
                | "C" -> `C (Ojs.int_of_js x202)
                | _ -> `D x202)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x202 "discr") with
-               | _ -> `D x202)
+          | "boolean" -> `D x202
           | _ -> `D x202
       and discr_poly_union_to_js : discr_poly_union -> Ojs.t =
         fun (x197 : [ `A  | `B of int  | `C of int  | `D of Ojs.t ]) ->
@@ -732,9 +726,7 @@ module T :
                | "42" -> B (Ojs.int_of_js x208)
                | "C" -> C (Ojs.int_of_js x208)
                | _ -> D x208)
-          | "boolean" ->
-              (match Ojs.bool_of_js (Ojs.get_prop_ascii x208 "discr") with
-               | _ -> D x208)
+          | "boolean" -> D x208
           | _ -> D x208
       and discr_union_value_to_js : discr_union_value -> Ojs.t =
         fun (x203 : discr_union_value) ->

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -554,6 +554,7 @@ module T :
         fun (x167 : Ojs.t) ->
           let x168 = x167 in
           match Ojs.type_of (Ojs.get_prop_ascii x168 "kind") with
+          | "number" -> Unknown x168
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x168 "kind") with
                | "A" -> A
@@ -608,6 +609,7 @@ module T :
         fun (x177 : Ojs.t) ->
           let x178 = x177 in
           match Ojs.type_of (Ojs.get_prop_ascii x178 "kind") with
+          | "number" -> Unknown x178
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x178 "kind") with
                | "A" -> A
@@ -683,6 +685,7 @@ module T :
         fun (x195 : Ojs.t) ->
           let x196 = x195 in
           match Ojs.type_of (Ojs.get_prop_ascii x196 "discr") with
+          | "number" -> D x196
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x196 "discr") with
                | "A" -> A
@@ -703,6 +706,7 @@ module T :
         fun (x201 : Ojs.t) ->
           let x202 = x201 in
           match Ojs.type_of (Ojs.get_prop_ascii x202 "discr") with
+          | "number" -> `D x202
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x202 "discr") with
                | "A" -> `A
@@ -727,6 +731,10 @@ module T :
         fun (x207 : Ojs.t) ->
           let x208 = x207 in
           match Ojs.type_of (Ojs.get_prop_ascii x208 "discr") with
+          | "number" ->
+              (match Ojs.int_of_js (Ojs.get_prop_ascii x208 "discr") with
+               | 0 -> A
+               | _ -> D x208)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x208 "discr") with
                | "42" -> B (Ojs.int_of_js x208)

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -463,11 +463,11 @@ module T :
           let x145 = x144 in
           match Ojs.type_of x145 with
           | "number" ->
-              (match Ojs.int_of_js x145 with
-               | 42 -> Bar
+              (match Ojs.float_of_js x145 with
+               | 4.2 -> Baz
                | _ ->
-                   (match Ojs.float_of_js x145 with
-                    | 4.2 -> Baz
+                   (match Ojs.int_of_js x145 with
+                    | 42 -> Bar
                     | _ -> assert false))
           | "string" ->
               (match Ojs.string_of_js x145 with
@@ -717,10 +717,6 @@ module T :
         fun (x207 : Ojs.t) ->
           let x208 = x207 in
           match Ojs.type_of (Ojs.get_prop_ascii x208 "discr") with
-          | "number" ->
-              (match Ojs.int_of_js (Ojs.get_prop_ascii x208 "discr") with
-               | 0 -> A
-               | _ -> D x208)
           | "string" ->
               (match Ojs.string_of_js (Ojs.get_prop_ascii x208 "discr") with
                | "42" -> B (Ojs.int_of_js x208)

--- a/ppx-test/expected/union_and_enum.ml
+++ b/ppx-test/expected/union_and_enum.ml
@@ -305,6 +305,11 @@ let rec union_int_of_js : Ojs.t -> union_int =
   fun (x76 : Ojs.t) ->
     let x77 = x76 in
     match Ojs.type_of (Ojs.get_prop_ascii x77 "tag") with
+    | "number" ->
+        (match Ojs.int_of_js (Ojs.get_prop_ascii x77 "tag") with
+         | 0 -> Union_int_0 (dummy1_of_js x77)
+         | 1 -> Union_int_1 (dummy2_of_js x77)
+         | _ -> Unknown x77)
     | "string" -> Unknown x77
     | "boolean" -> Unknown x77
     | _ -> Unknown x77
@@ -344,6 +349,7 @@ let rec union_string_of_js : Ojs.t -> union_string =
   fun (x88 : Ojs.t) ->
     let x89 = x88 in
     match Ojs.type_of (Ojs.get_prop_ascii x89 "tag") with
+    | "number" -> Unknown x89
     | "string" ->
         (match Ojs.string_of_js (Ojs.get_prop_ascii x89 "tag") with
          | "foo" -> Union_string_foo (dummy3_of_js x89)
@@ -389,6 +395,7 @@ let rec union_bool_partial2_of_js : Ojs.t -> union_bool_partial2 =
   fun (x102 : Ojs.t) ->
     let x103 = x102 in
     match Ojs.type_of (Ojs.get_prop_ascii x103 "tag") with
+    | "number" -> Unknown x103
     | "string" -> Unknown x103
     | "boolean" ->
         (match Ojs.bool_of_js (Ojs.get_prop_ascii x103 "tag") with

--- a/ppx-test/expected/union_and_enum.ml
+++ b/ppx-test/expected/union_and_enum.ml
@@ -39,18 +39,18 @@ type enum_number_1 =
   | Enum_number_1 
   | Enum_number_0_1 
   | Enum_number_1_1 
-  | Enum_number_other of float 
+  | Enum_number_other of int 
 let rec enum_number_1_of_js : Ojs.t -> enum_number_1 =
   fun (x13 : Ojs.t) ->
     let x14 = x13 in
     match Ojs.float_of_js x14 with
     | 0.1 -> Enum_number_0_1
     | 1.1 -> Enum_number_1_1
-    | x15 ->
+    | _ ->
         (match Ojs.int_of_js x14 with
          | 0 -> Enum_number_0
          | 1 -> Enum_number_1
-         | _ -> Enum_number_other x15)
+         | x15 -> Enum_number_other x15)
 and enum_number_1_to_js : enum_number_1 -> Ojs.t =
   fun (x11 : enum_number_1) ->
     match x11 with
@@ -58,24 +58,24 @@ and enum_number_1_to_js : enum_number_1 -> Ojs.t =
     | Enum_number_1 -> Ojs.int_to_js 1
     | Enum_number_0_1 -> Ojs.float_to_js 0.1
     | Enum_number_1_1 -> Ojs.float_to_js 1.1
-    | Enum_number_other x12 -> Ojs.float_to_js x12
+    | Enum_number_other x12 -> Ojs.int_to_js x12
 type enum_number_2 =
   | Enum_number_0 
   | Enum_number_1 
   | Enum_number_0_1 
   | Enum_number_1_1 
-  | Enum_number_other of int 
+  | Enum_number_other of float 
 let rec enum_number_2_of_js : Ojs.t -> enum_number_2 =
   fun (x18 : Ojs.t) ->
     let x19 = x18 in
     match Ojs.float_of_js x19 with
     | 0.1 -> Enum_number_0_1
     | 1.1 -> Enum_number_1_1
-    | _ ->
+    | x20 ->
         (match Ojs.int_of_js x19 with
          | 0 -> Enum_number_0
          | 1 -> Enum_number_1
-         | x20 -> Enum_number_other x20)
+         | _ -> Enum_number_other x20)
 and enum_number_2_to_js : enum_number_2 -> Ojs.t =
   fun (x16 : enum_number_2) ->
     match x16 with
@@ -83,7 +83,7 @@ and enum_number_2_to_js : enum_number_2 -> Ojs.t =
     | Enum_number_1 -> Ojs.int_to_js 1
     | Enum_number_0_1 -> Ojs.float_to_js 0.1
     | Enum_number_1_1 -> Ojs.float_to_js 1.1
-    | Enum_number_other x17 -> Ojs.int_to_js x17
+    | Enum_number_other x17 -> Ojs.float_to_js x17
 type enum_string =
   | Enum_string_foo 
   | Enum_string_bar 
@@ -321,7 +321,7 @@ and union_int_to_js : union_int -> Ojs.t =
     | Unknown x75 -> x75
 type union_float =
   | Union_float_0_1 of dummy1 
-  | Union_float_1_1 of dummy1 
+  | Union_float_1_1 of dummy2 
   | Unknown of Ojs.t 
 let rec union_float_of_js : Ojs.t -> union_float =
   fun (x82 : Ojs.t) ->
@@ -330,7 +330,7 @@ let rec union_float_of_js : Ojs.t -> union_float =
     | "number" ->
         (match Ojs.float_of_js (Ojs.get_prop_ascii x83 "tag") with
          | 0.1 -> Union_float_0_1 (dummy1_of_js x83)
-         | 1.1 -> Union_float_1_1 (dummy1_of_js x83)
+         | 1.1 -> Union_float_1_1 (dummy2_of_js x83)
          | _ -> Unknown x83)
     | "string" -> Unknown x83
     | "boolean" -> Unknown x83
@@ -339,7 +339,7 @@ and union_float_to_js : union_float -> Ojs.t =
   fun (x78 : union_float) ->
     match x78 with
     | Union_float_0_1 x79 -> dummy1_to_js x79
-    | Union_float_1_1 x80 -> dummy1_to_js x80
+    | Union_float_1_1 x80 -> dummy2_to_js x80
     | Unknown x81 -> x81
 type union_string =
   | Union_string_foo of dummy3 
@@ -411,7 +411,7 @@ type union_mixed =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
   | Union_float_0_1 of dummy1 
-  | Union_float_1_1 of dummy1 
+  | Union_float_1_1 of dummy2 
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Union_bool_true of dummy5 
@@ -424,7 +424,7 @@ let rec union_mixed_of_js : Ojs.t -> union_mixed =
     | "number" ->
         (match Ojs.float_of_js (Ojs.get_prop_ascii x115 "tag") with
          | 0.1 -> Union_float_0_1 (dummy1_of_js x115)
-         | 1.1 -> Union_float_1_1 (dummy1_of_js x115)
+         | 1.1 -> Union_float_1_1 (dummy2_of_js x115)
          | _ ->
              (match Ojs.int_of_js (Ojs.get_prop_ascii x115 "tag") with
               | 0 -> Union_int_0 (dummy1_of_js x115)
@@ -446,7 +446,7 @@ and union_mixed_to_js : union_mixed -> Ojs.t =
     | Union_int_0 x105 -> dummy1_to_js x105
     | Union_int_1 x106 -> dummy2_to_js x106
     | Union_float_0_1 x107 -> dummy1_to_js x107
-    | Union_float_1_1 x108 -> dummy1_to_js x108
+    | Union_float_1_1 x108 -> dummy2_to_js x108
     | Union_string_foo x109 -> dummy3_to_js x109
     | Union_string_bar x110 -> dummy4_to_js x110
     | Union_bool_true x111 -> dummy5_to_js x111
@@ -456,7 +456,7 @@ type union_mixed_partial_bool =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
   | Union_float_0_1 of dummy1 
-  | Union_float_1_1 of dummy1 
+  | Union_float_1_1 of dummy2 
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Union_bool_true of dummy5 
@@ -468,7 +468,7 @@ let rec union_mixed_partial_bool_of_js : Ojs.t -> union_mixed_partial_bool =
     | "number" ->
         (match Ojs.float_of_js (Ojs.get_prop_ascii x126 "tag") with
          | 0.1 -> Union_float_0_1 (dummy1_of_js x126)
-         | 1.1 -> Union_float_1_1 (dummy1_of_js x126)
+         | 1.1 -> Union_float_1_1 (dummy2_of_js x126)
          | _ ->
              (match Ojs.int_of_js (Ojs.get_prop_ascii x126 "tag") with
               | 0 -> Union_int_0 (dummy1_of_js x126)
@@ -490,7 +490,7 @@ and union_mixed_partial_bool_to_js : union_mixed_partial_bool -> Ojs.t =
     | Union_int_0 x117 -> dummy1_to_js x117
     | Union_int_1 x118 -> dummy2_to_js x118
     | Union_float_0_1 x119 -> dummy1_to_js x119
-    | Union_float_1_1 x120 -> dummy1_to_js x120
+    | Union_float_1_1 x120 -> dummy2_to_js x120
     | Union_string_foo x121 -> dummy3_to_js x121
     | Union_string_bar x122 -> dummy4_to_js x122
     | Union_bool_true x123 -> dummy5_to_js x123

--- a/ppx-test/expected/union_and_enum.ml
+++ b/ppx-test/expected/union_and_enum.ml
@@ -34,87 +34,112 @@ and enum_float_to_js : enum_float -> Ojs.t =
     | Enum_float_0_1 -> Ojs.float_to_js 0.1
     | Enum_float_1_1 -> Ojs.float_to_js 1.1
     | Enum_float_other x7 -> Ojs.float_to_js x7
-type enum_number =
+type enum_number_1 =
   | Enum_number_0 
   | Enum_number_1 
   | Enum_number_0_1 
   | Enum_number_1_1 
   | Enum_number_other of float 
-let rec enum_number_of_js : Ojs.t -> enum_number =
+let rec enum_number_1_of_js : Ojs.t -> enum_number_1 =
   fun (x13 : Ojs.t) ->
     let x14 = x13 in
-    match Ojs.int_of_js x14 with
-    | 0 -> Enum_number_0
-    | 1 -> Enum_number_1
-    | _ ->
-        (match Ojs.float_of_js x14 with
-         | 0.1 -> Enum_number_0_1
-         | 1.1 -> Enum_number_1_1
-         | x15 -> Enum_number_other x15)
-and enum_number_to_js : enum_number -> Ojs.t =
-  fun (x11 : enum_number) ->
+    match Ojs.float_of_js x14 with
+    | 0.1 -> Enum_number_0_1
+    | 1.1 -> Enum_number_1_1
+    | x15 ->
+        (match Ojs.int_of_js x14 with
+         | 0 -> Enum_number_0
+         | 1 -> Enum_number_1
+         | _ -> Enum_number_other x15)
+and enum_number_1_to_js : enum_number_1 -> Ojs.t =
+  fun (x11 : enum_number_1) ->
     match x11 with
     | Enum_number_0 -> Ojs.int_to_js 0
     | Enum_number_1 -> Ojs.int_to_js 1
     | Enum_number_0_1 -> Ojs.float_to_js 0.1
     | Enum_number_1_1 -> Ojs.float_to_js 1.1
     | Enum_number_other x12 -> Ojs.float_to_js x12
+type enum_number_2 =
+  | Enum_number_0 
+  | Enum_number_1 
+  | Enum_number_0_1 
+  | Enum_number_1_1 
+  | Enum_number_other of int 
+let rec enum_number_2_of_js : Ojs.t -> enum_number_2 =
+  fun (x18 : Ojs.t) ->
+    let x19 = x18 in
+    match Ojs.float_of_js x19 with
+    | 0.1 -> Enum_number_0_1
+    | 1.1 -> Enum_number_1_1
+    | _ ->
+        (match Ojs.int_of_js x19 with
+         | 0 -> Enum_number_0
+         | 1 -> Enum_number_1
+         | x20 -> Enum_number_other x20)
+and enum_number_2_to_js : enum_number_2 -> Ojs.t =
+  fun (x16 : enum_number_2) ->
+    match x16 with
+    | Enum_number_0 -> Ojs.int_to_js 0
+    | Enum_number_1 -> Ojs.int_to_js 1
+    | Enum_number_0_1 -> Ojs.float_to_js 0.1
+    | Enum_number_1_1 -> Ojs.float_to_js 1.1
+    | Enum_number_other x17 -> Ojs.int_to_js x17
 type enum_string =
   | Enum_string_foo 
   | Enum_string_bar 
   | Enum_string_other of string 
 let rec enum_string_of_js : Ojs.t -> enum_string =
-  fun (x18 : Ojs.t) ->
-    let x19 = x18 in
-    match Ojs.string_of_js x19 with
+  fun (x23 : Ojs.t) ->
+    let x24 = x23 in
+    match Ojs.string_of_js x24 with
     | "foo" -> Enum_string_foo
     | "bar" -> Enum_string_bar
-    | x20 -> Enum_string_other x20
+    | x25 -> Enum_string_other x25
 and enum_string_to_js : enum_string -> Ojs.t =
-  fun (x16 : enum_string) ->
-    match x16 with
+  fun (x21 : enum_string) ->
+    match x21 with
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x17 -> Ojs.string_to_js x17
+    | Enum_string_other x22 -> Ojs.string_to_js x22
 type enum_bool =
   | Enum_bool_true 
   | Enum_bool_false 
 let rec enum_bool_of_js : Ojs.t -> enum_bool =
-  fun (x22 : Ojs.t) ->
-    let x23 = x22 in
-    match Ojs.bool_of_js x23 with
+  fun (x27 : Ojs.t) ->
+    let x28 = x27 in
+    match Ojs.bool_of_js x28 with
     | true -> Enum_bool_true
     | false -> Enum_bool_false
 and enum_bool_to_js : enum_bool -> Ojs.t =
-  fun (x21 : enum_bool) ->
-    match x21 with
+  fun (x26 : enum_bool) ->
+    match x26 with
     | Enum_bool_true -> Ojs.bool_to_js true
     | Enum_bool_false -> Ojs.bool_to_js false
 type enum_bool_partial =
   | Enum_bool_true 
 let rec enum_bool_partial_of_js : Ojs.t -> enum_bool_partial =
-  fun (x25 : Ojs.t) ->
-    let x26 = x25 in
-    match Ojs.bool_of_js x26 with
+  fun (x30 : Ojs.t) ->
+    let x31 = x30 in
+    match Ojs.bool_of_js x31 with
     | true -> Enum_bool_true
     | _ -> assert false
 and enum_bool_partial_to_js : enum_bool_partial -> Ojs.t =
-  fun (x24 : enum_bool_partial) ->
-    match x24 with | Enum_bool_true -> Ojs.bool_to_js true
+  fun (x29 : enum_bool_partial) ->
+    match x29 with | Enum_bool_true -> Ojs.bool_to_js true
 type enum_bool_partial2 =
   | Enum_bool_true 
   | Enum_bool_other of bool 
 let rec enum_bool_partial2_of_js : Ojs.t -> enum_bool_partial2 =
-  fun (x29 : Ojs.t) ->
-    let x30 = x29 in
-    match Ojs.bool_of_js x30 with
+  fun (x34 : Ojs.t) ->
+    let x35 = x34 in
+    match Ojs.bool_of_js x35 with
     | true -> Enum_bool_true
-    | x31 -> Enum_bool_other x31
+    | x36 -> Enum_bool_other x36
 and enum_bool_partial2_to_js : enum_bool_partial2 -> Ojs.t =
-  fun (x27 : enum_bool_partial2) ->
-    match x27 with
+  fun (x32 : enum_bool_partial2) ->
+    match x32 with
     | Enum_bool_true -> Ojs.bool_to_js true
-    | Enum_bool_other x28 -> Ojs.bool_to_js x28
+    | Enum_bool_other x33 -> Ojs.bool_to_js x33
 type enum_mixed =
   | Enum_int_0 
   | Enum_int_1 
@@ -127,39 +152,39 @@ type enum_mixed =
   | Enum_bool_true 
   | Enum_bool_false 
 let rec enum_mixed_of_js : Ojs.t -> enum_mixed =
-  fun (x35 : Ojs.t) ->
-    let x36 = x35 in
-    match Ojs.type_of x36 with
+  fun (x40 : Ojs.t) ->
+    let x41 = x40 in
+    match Ojs.type_of x41 with
     | "number" ->
-        (match Ojs.float_of_js x36 with
+        (match Ojs.float_of_js x41 with
          | 0.1 -> Enum_float_0_1
          | 1.1 -> Enum_float_1_1
          | _ ->
-             (match Ojs.int_of_js x36 with
+             (match Ojs.int_of_js x41 with
               | 0 -> Enum_int_0
               | 1 -> Enum_int_1
-              | x37 -> Enum_number_other x37))
+              | x42 -> Enum_number_other x42))
     | "string" ->
-        (match Ojs.string_of_js x36 with
+        (match Ojs.string_of_js x41 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x38 -> Enum_string_other x38)
+         | x43 -> Enum_string_other x43)
     | "boolean" ->
-        (match Ojs.bool_of_js x36 with
+        (match Ojs.bool_of_js x41 with
          | true -> Enum_bool_true
          | false -> Enum_bool_false)
     | _ -> assert false
 and enum_mixed_to_js : enum_mixed -> Ojs.t =
-  fun (x32 : enum_mixed) ->
-    match x32 with
+  fun (x37 : enum_mixed) ->
+    match x37 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
     | Enum_float_0_1 -> Ojs.float_to_js 0.1
     | Enum_float_1_1 -> Ojs.float_to_js 1.1
-    | Enum_number_other x33 -> Ojs.int_to_js x33
+    | Enum_number_other x38 -> Ojs.int_to_js x38
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x34 -> Ojs.string_to_js x34
+    | Enum_string_other x39 -> Ojs.string_to_js x39
     | Enum_bool_true -> Ojs.bool_to_js true
     | Enum_bool_false -> Ojs.bool_to_js false
 type enum_mixed_partial_bool =
@@ -173,39 +198,39 @@ type enum_mixed_partial_bool =
   | Enum_string_other of string 
   | Enum_bool_true 
 let rec enum_mixed_partial_bool_of_js : Ojs.t -> enum_mixed_partial_bool =
-  fun (x42 : Ojs.t) ->
-    let x43 = x42 in
-    match Ojs.type_of x43 with
+  fun (x47 : Ojs.t) ->
+    let x48 = x47 in
+    match Ojs.type_of x48 with
     | "number" ->
-        (match Ojs.int_of_js x43 with
-         | 0 -> Enum_int_0
-         | 1 -> Enum_int_1
-         | _ ->
-             (match Ojs.float_of_js x43 with
-              | 0.1 -> Enum_float_0_1
-              | 1.1 -> Enum_float_1_1
-              | x44 -> Enum_number_other x44))
+        (match Ojs.float_of_js x48 with
+         | 0.1 -> Enum_float_0_1
+         | 1.1 -> Enum_float_1_1
+         | x49 ->
+             (match Ojs.int_of_js x48 with
+              | 0 -> Enum_int_0
+              | 1 -> Enum_int_1
+              | _ -> Enum_number_other x49))
     | "string" ->
-        (match Ojs.string_of_js x43 with
+        (match Ojs.string_of_js x48 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x45 -> Enum_string_other x45)
+         | x50 -> Enum_string_other x50)
     | "boolean" ->
-        (match Ojs.bool_of_js x43 with
+        (match Ojs.bool_of_js x48 with
          | true -> Enum_bool_true
          | _ -> assert false)
     | _ -> assert false
 and enum_mixed_partial_bool_to_js : enum_mixed_partial_bool -> Ojs.t =
-  fun (x39 : enum_mixed_partial_bool) ->
-    match x39 with
+  fun (x44 : enum_mixed_partial_bool) ->
+    match x44 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
     | Enum_float_0_1 -> Ojs.float_to_js 0.1
     | Enum_float_1_1 -> Ojs.float_to_js 1.1
-    | Enum_number_other x40 -> Ojs.float_to_js x40
+    | Enum_number_other x45 -> Ojs.float_to_js x45
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x41 -> Ojs.string_to_js x41
+    | Enum_string_other x46 -> Ojs.string_to_js x46
     | Enum_bool_true -> Ojs.bool_to_js true
 type enum_mixed_partial_bool2 =
   | Enum_int_0 
@@ -219,162 +244,162 @@ type enum_mixed_partial_bool2 =
   | Enum_bool_true 
   | Enum_bool_other of bool 
 let rec enum_mixed_partial_bool2_of_js : Ojs.t -> enum_mixed_partial_bool2 =
-  fun (x50 : Ojs.t) ->
-    let x51 = x50 in
-    match Ojs.type_of x51 with
+  fun (x55 : Ojs.t) ->
+    let x56 = x55 in
+    match Ojs.type_of x56 with
     | "number" ->
-        (match Ojs.int_of_js x51 with
-         | 0 -> Enum_int_0
-         | 1 -> Enum_int_1
-         | _ ->
-             (match Ojs.float_of_js x51 with
-              | 0.1 -> Enum_float_0_1
-              | 1.1 -> Enum_float_1_1
-              | x52 -> Enum_number_other x52))
+        (match Ojs.float_of_js x56 with
+         | 0.1 -> Enum_float_0_1
+         | 1.1 -> Enum_float_1_1
+         | x57 ->
+             (match Ojs.int_of_js x56 with
+              | 0 -> Enum_int_0
+              | 1 -> Enum_int_1
+              | _ -> Enum_number_other x57))
     | "string" ->
-        (match Ojs.string_of_js x51 with
+        (match Ojs.string_of_js x56 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x53 -> Enum_string_other x53)
+         | x58 -> Enum_string_other x58)
     | "boolean" ->
-        (match Ojs.bool_of_js x51 with
+        (match Ojs.bool_of_js x56 with
          | true -> Enum_bool_true
-         | x54 -> Enum_bool_other x54)
+         | x59 -> Enum_bool_other x59)
     | _ -> assert false
 and enum_mixed_partial_bool2_to_js : enum_mixed_partial_bool2 -> Ojs.t =
-  fun (x46 : enum_mixed_partial_bool2) ->
-    match x46 with
+  fun (x51 : enum_mixed_partial_bool2) ->
+    match x51 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
     | Enum_float_0_1 -> Ojs.float_to_js 0.1
     | Enum_float_1_1 -> Ojs.float_to_js 1.1
-    | Enum_number_other x47 -> Ojs.float_to_js x47
+    | Enum_number_other x52 -> Ojs.float_to_js x52
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x48 -> Ojs.string_to_js x48
+    | Enum_string_other x53 -> Ojs.string_to_js x53
     | Enum_bool_true -> Ojs.bool_to_js true
-    | Enum_bool_other x49 -> Ojs.bool_to_js x49
+    | Enum_bool_other x54 -> Ojs.bool_to_js x54
 type dummy1 = Ojs.t
-let rec dummy1_of_js : Ojs.t -> dummy1 = fun (x56 : Ojs.t) -> x56
-and dummy1_to_js : dummy1 -> Ojs.t = fun (x55 : Ojs.t) -> x55
+let rec dummy1_of_js : Ojs.t -> dummy1 = fun (x61 : Ojs.t) -> x61
+and dummy1_to_js : dummy1 -> Ojs.t = fun (x60 : Ojs.t) -> x60
 type dummy2 = Ojs.t
-let rec dummy2_of_js : Ojs.t -> dummy2 = fun (x58 : Ojs.t) -> x58
-and dummy2_to_js : dummy2 -> Ojs.t = fun (x57 : Ojs.t) -> x57
+let rec dummy2_of_js : Ojs.t -> dummy2 = fun (x63 : Ojs.t) -> x63
+and dummy2_to_js : dummy2 -> Ojs.t = fun (x62 : Ojs.t) -> x62
 type dummy3 = Ojs.t
-let rec dummy3_of_js : Ojs.t -> dummy3 = fun (x60 : Ojs.t) -> x60
-and dummy3_to_js : dummy3 -> Ojs.t = fun (x59 : Ojs.t) -> x59
+let rec dummy3_of_js : Ojs.t -> dummy3 = fun (x65 : Ojs.t) -> x65
+and dummy3_to_js : dummy3 -> Ojs.t = fun (x64 : Ojs.t) -> x64
 type dummy4 = Ojs.t
-let rec dummy4_of_js : Ojs.t -> dummy4 = fun (x62 : Ojs.t) -> x62
-and dummy4_to_js : dummy4 -> Ojs.t = fun (x61 : Ojs.t) -> x61
+let rec dummy4_of_js : Ojs.t -> dummy4 = fun (x67 : Ojs.t) -> x67
+and dummy4_to_js : dummy4 -> Ojs.t = fun (x66 : Ojs.t) -> x66
 type dummy5 = Ojs.t
-let rec dummy5_of_js : Ojs.t -> dummy5 = fun (x64 : Ojs.t) -> x64
-and dummy5_to_js : dummy5 -> Ojs.t = fun (x63 : Ojs.t) -> x63
+let rec dummy5_of_js : Ojs.t -> dummy5 = fun (x69 : Ojs.t) -> x69
+and dummy5_to_js : dummy5 -> Ojs.t = fun (x68 : Ojs.t) -> x68
 type dummy6 = Ojs.t
-let rec dummy6_of_js : Ojs.t -> dummy6 = fun (x66 : Ojs.t) -> x66
-and dummy6_to_js : dummy6 -> Ojs.t = fun (x65 : Ojs.t) -> x65
+let rec dummy6_of_js : Ojs.t -> dummy6 = fun (x71 : Ojs.t) -> x71
+and dummy6_to_js : dummy6 -> Ojs.t = fun (x70 : Ojs.t) -> x70
 type union_int =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
   | Unknown of Ojs.t 
 let rec union_int_of_js : Ojs.t -> union_int =
-  fun (x71 : Ojs.t) ->
-    let x72 = x71 in
-    match Ojs.type_of (Ojs.get_prop_ascii x72 "tag") with
-    | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x72 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x72)
-         | 1 -> Union_int_1 (dummy2_of_js x72)
-         | _ -> Unknown x72)
-    | "string" -> Unknown x72
-    | "boolean" -> Unknown x72
-    | _ -> Unknown x72
+  fun (x76 : Ojs.t) ->
+    let x77 = x76 in
+    match Ojs.type_of (Ojs.get_prop_ascii x77 "tag") with
+    | "string" -> Unknown x77
+    | "boolean" -> Unknown x77
+    | _ -> Unknown x77
 and union_int_to_js : union_int -> Ojs.t =
-  fun (x67 : union_int) ->
-    match x67 with
-    | Union_int_0 x68 -> dummy1_to_js x68
-    | Union_int_1 x69 -> dummy2_to_js x69
-    | Unknown x70 -> x70
+  fun (x72 : union_int) ->
+    match x72 with
+    | Union_int_0 x73 -> dummy1_to_js x73
+    | Union_int_1 x74 -> dummy2_to_js x74
+    | Unknown x75 -> x75
 type union_float =
   | Union_float_0_1 of dummy1 
   | Union_float_1_1 of dummy1 
   | Unknown of Ojs.t 
 let rec union_float_of_js : Ojs.t -> union_float =
-  fun (x77 : Ojs.t) ->
-    let x78 = x77 in
-    match Ojs.type_of (Ojs.get_prop_ascii x78 "tag") with
-    | "string" -> Unknown x78
-    | "boolean" -> Unknown x78
-    | _ -> Unknown x78
+  fun (x82 : Ojs.t) ->
+    let x83 = x82 in
+    match Ojs.type_of (Ojs.get_prop_ascii x83 "tag") with
+    | "number" ->
+        (match Ojs.float_of_js (Ojs.get_prop_ascii x83 "tag") with
+         | 0.1 -> Union_float_0_1 (dummy1_of_js x83)
+         | 1.1 -> Union_float_1_1 (dummy1_of_js x83)
+         | _ -> Unknown x83)
+    | "string" -> Unknown x83
+    | "boolean" -> Unknown x83
+    | _ -> Unknown x83
 and union_float_to_js : union_float -> Ojs.t =
-  fun (x73 : union_float) ->
-    match x73 with
-    | Union_float_0_1 x74 -> dummy1_to_js x74
-    | Union_float_1_1 x75 -> dummy1_to_js x75
-    | Unknown x76 -> x76
+  fun (x78 : union_float) ->
+    match x78 with
+    | Union_float_0_1 x79 -> dummy1_to_js x79
+    | Union_float_1_1 x80 -> dummy1_to_js x80
+    | Unknown x81 -> x81
 type union_string =
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Unknown of Ojs.t 
 let rec union_string_of_js : Ojs.t -> union_string =
-  fun (x83 : Ojs.t) ->
-    let x84 = x83 in
-    match Ojs.type_of (Ojs.get_prop_ascii x84 "tag") with
+  fun (x88 : Ojs.t) ->
+    let x89 = x88 in
+    match Ojs.type_of (Ojs.get_prop_ascii x89 "tag") with
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x84 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x84)
-         | "bar" -> Union_string_bar (dummy4_of_js x84)
-         | _ -> Unknown x84)
-    | "boolean" -> Unknown x84
-    | _ -> Unknown x84
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x89 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x89)
+         | "bar" -> Union_string_bar (dummy4_of_js x89)
+         | _ -> Unknown x89)
+    | "boolean" -> Unknown x89
+    | _ -> Unknown x89
 and union_string_to_js : union_string -> Ojs.t =
-  fun (x79 : union_string) ->
-    match x79 with
-    | Union_string_foo x80 -> dummy3_to_js x80
-    | Union_string_bar x81 -> dummy4_to_js x81
-    | Unknown x82 -> x82
+  fun (x84 : union_string) ->
+    match x84 with
+    | Union_string_foo x85 -> dummy3_to_js x85
+    | Union_string_bar x86 -> dummy4_to_js x86
+    | Unknown x87 -> x87
 type union_bool =
   | Union_bool_true of dummy5 
   | Union_bool_false of dummy6 
 let rec union_bool_of_js : Ojs.t -> union_bool =
-  fun (x88 : Ojs.t) ->
-    let x89 = x88 in
-    match Ojs.bool_of_js (Ojs.get_prop_ascii x89 "tag") with
-    | true -> Union_bool_true (dummy5_of_js x89)
-    | false -> Union_bool_false (dummy6_of_js x89)
+  fun (x93 : Ojs.t) ->
+    let x94 = x93 in
+    match Ojs.bool_of_js (Ojs.get_prop_ascii x94 "tag") with
+    | true -> Union_bool_true (dummy5_of_js x94)
+    | false -> Union_bool_false (dummy6_of_js x94)
 and union_bool_to_js : union_bool -> Ojs.t =
-  fun (x85 : union_bool) ->
-    match x85 with
-    | Union_bool_true x86 -> dummy5_to_js x86
-    | Union_bool_false x87 -> dummy6_to_js x87
+  fun (x90 : union_bool) ->
+    match x90 with
+    | Union_bool_true x91 -> dummy5_to_js x91
+    | Union_bool_false x92 -> dummy6_to_js x92
 type union_bool_partial =
   | Union_bool_true of dummy5 
 let rec union_bool_partial_of_js : Ojs.t -> union_bool_partial =
-  fun (x92 : Ojs.t) ->
-    let x93 = x92 in
-    match Ojs.bool_of_js (Ojs.get_prop_ascii x93 "tag") with
-    | true -> Union_bool_true (dummy5_of_js x93)
+  fun (x97 : Ojs.t) ->
+    let x98 = x97 in
+    match Ojs.bool_of_js (Ojs.get_prop_ascii x98 "tag") with
+    | true -> Union_bool_true (dummy5_of_js x98)
     | _ -> assert false
 and union_bool_partial_to_js : union_bool_partial -> Ojs.t =
-  fun (x90 : union_bool_partial) ->
-    match x90 with | Union_bool_true x91 -> dummy5_to_js x91
+  fun (x95 : union_bool_partial) ->
+    match x95 with | Union_bool_true x96 -> dummy5_to_js x96
 type union_bool_partial2 =
   | Union_bool_true of dummy5 
   | Unknown of Ojs.t 
 let rec union_bool_partial2_of_js : Ojs.t -> union_bool_partial2 =
-  fun (x97 : Ojs.t) ->
-    let x98 = x97 in
-    match Ojs.type_of (Ojs.get_prop_ascii x98 "tag") with
-    | "string" -> Unknown x98
+  fun (x102 : Ojs.t) ->
+    let x103 = x102 in
+    match Ojs.type_of (Ojs.get_prop_ascii x103 "tag") with
+    | "string" -> Unknown x103
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x98 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x98)
-         | _ -> Unknown x98)
-    | _ -> Unknown x98
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x103 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x103)
+         | _ -> Unknown x103)
+    | _ -> Unknown x103
 and union_bool_partial2_to_js : union_bool_partial2 -> Ojs.t =
-  fun (x94 : union_bool_partial2) ->
-    match x94 with
-    | Union_bool_true x95 -> dummy5_to_js x95
-    | Unknown x96 -> x96
+  fun (x99 : union_bool_partial2) ->
+    match x99 with
+    | Union_bool_true x100 -> dummy5_to_js x100
+    | Unknown x101 -> x101
 type union_mixed =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
@@ -386,40 +411,40 @@ type union_mixed =
   | Union_bool_false of dummy6 
   | Unknown of Ojs.t 
 let rec union_mixed_of_js : Ojs.t -> union_mixed =
-  fun (x109 : Ojs.t) ->
-    let x110 = x109 in
-    match Ojs.type_of (Ojs.get_prop_ascii x110 "tag") with
+  fun (x114 : Ojs.t) ->
+    let x115 = x114 in
+    match Ojs.type_of (Ojs.get_prop_ascii x115 "tag") with
     | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x110 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x110)
-         | 1 -> Union_int_1 (dummy2_of_js x110)
+        (match Ojs.float_of_js (Ojs.get_prop_ascii x115 "tag") with
+         | 0.1 -> Union_float_0_1 (dummy1_of_js x115)
+         | 1.1 -> Union_float_1_1 (dummy1_of_js x115)
          | _ ->
-             (match Ojs.float_of_js (Ojs.get_prop_ascii x110 "tag") with
-              | 0.1 -> Union_float_0_1 (dummy1_of_js x110)
-              | 1.1 -> Union_float_1_1 (dummy1_of_js x110)
-              | _ -> Unknown x110))
+             (match Ojs.int_of_js (Ojs.get_prop_ascii x115 "tag") with
+              | 0 -> Union_int_0 (dummy1_of_js x115)
+              | 1 -> Union_int_1 (dummy2_of_js x115)
+              | _ -> Unknown x115))
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x110 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x110)
-         | "bar" -> Union_string_bar (dummy4_of_js x110)
-         | _ -> Unknown x110)
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x115 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x115)
+         | "bar" -> Union_string_bar (dummy4_of_js x115)
+         | _ -> Unknown x115)
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x110 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x110)
-         | false -> Union_bool_false (dummy6_of_js x110))
-    | _ -> Unknown x110
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x115 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x115)
+         | false -> Union_bool_false (dummy6_of_js x115))
+    | _ -> Unknown x115
 and union_mixed_to_js : union_mixed -> Ojs.t =
-  fun (x99 : union_mixed) ->
-    match x99 with
-    | Union_int_0 x100 -> dummy1_to_js x100
-    | Union_int_1 x101 -> dummy2_to_js x101
-    | Union_float_0_1 x102 -> dummy1_to_js x102
-    | Union_float_1_1 x103 -> dummy1_to_js x103
-    | Union_string_foo x104 -> dummy3_to_js x104
-    | Union_string_bar x105 -> dummy4_to_js x105
-    | Union_bool_true x106 -> dummy5_to_js x106
-    | Union_bool_false x107 -> dummy6_to_js x107
-    | Unknown x108 -> x108
+  fun (x104 : union_mixed) ->
+    match x104 with
+    | Union_int_0 x105 -> dummy1_to_js x105
+    | Union_int_1 x106 -> dummy2_to_js x106
+    | Union_float_0_1 x107 -> dummy1_to_js x107
+    | Union_float_1_1 x108 -> dummy1_to_js x108
+    | Union_string_foo x109 -> dummy3_to_js x109
+    | Union_string_bar x110 -> dummy4_to_js x110
+    | Union_bool_true x111 -> dummy5_to_js x111
+    | Union_bool_false x112 -> dummy6_to_js x112
+    | Unknown x113 -> x113
 type union_mixed_partial_bool =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
@@ -430,36 +455,36 @@ type union_mixed_partial_bool =
   | Union_bool_true of dummy5 
   | Unknown of Ojs.t 
 let rec union_mixed_partial_bool_of_js : Ojs.t -> union_mixed_partial_bool =
-  fun (x120 : Ojs.t) ->
-    let x121 = x120 in
-    match Ojs.type_of (Ojs.get_prop_ascii x121 "tag") with
+  fun (x125 : Ojs.t) ->
+    let x126 = x125 in
+    match Ojs.type_of (Ojs.get_prop_ascii x126 "tag") with
     | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x121 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x121)
-         | 1 -> Union_int_1 (dummy2_of_js x121)
+        (match Ojs.float_of_js (Ojs.get_prop_ascii x126 "tag") with
+         | 0.1 -> Union_float_0_1 (dummy1_of_js x126)
+         | 1.1 -> Union_float_1_1 (dummy1_of_js x126)
          | _ ->
-             (match Ojs.float_of_js (Ojs.get_prop_ascii x121 "tag") with
-              | 0.1 -> Union_float_0_1 (dummy1_of_js x121)
-              | 1.1 -> Union_float_1_1 (dummy1_of_js x121)
-              | _ -> Unknown x121))
+             (match Ojs.int_of_js (Ojs.get_prop_ascii x126 "tag") with
+              | 0 -> Union_int_0 (dummy1_of_js x126)
+              | 1 -> Union_int_1 (dummy2_of_js x126)
+              | _ -> Unknown x126))
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x121 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x121)
-         | "bar" -> Union_string_bar (dummy4_of_js x121)
-         | _ -> Unknown x121)
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x126 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x126)
+         | "bar" -> Union_string_bar (dummy4_of_js x126)
+         | _ -> Unknown x126)
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x121 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x121)
-         | _ -> Unknown x121)
-    | _ -> Unknown x121
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x126 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x126)
+         | _ -> Unknown x126)
+    | _ -> Unknown x126
 and union_mixed_partial_bool_to_js : union_mixed_partial_bool -> Ojs.t =
-  fun (x111 : union_mixed_partial_bool) ->
-    match x111 with
-    | Union_int_0 x112 -> dummy1_to_js x112
-    | Union_int_1 x113 -> dummy2_to_js x113
-    | Union_float_0_1 x114 -> dummy1_to_js x114
-    | Union_float_1_1 x115 -> dummy1_to_js x115
-    | Union_string_foo x116 -> dummy3_to_js x116
-    | Union_string_bar x117 -> dummy4_to_js x117
-    | Union_bool_true x118 -> dummy5_to_js x118
-    | Unknown x119 -> x119
+  fun (x116 : union_mixed_partial_bool) ->
+    match x116 with
+    | Union_int_0 x117 -> dummy1_to_js x117
+    | Union_int_1 x118 -> dummy2_to_js x118
+    | Union_float_0_1 x119 -> dummy1_to_js x119
+    | Union_float_1_1 x120 -> dummy1_to_js x120
+    | Union_string_foo x121 -> dummy3_to_js x121
+    | Union_string_bar x122 -> dummy4_to_js x122
+    | Union_bool_true x123 -> dummy5_to_js x123
+    | Unknown x124 -> x124

--- a/ppx-test/expected/union_and_enum.ml
+++ b/ppx-test/expected/union_and_enum.ml
@@ -17,364 +17,449 @@ and enum_int_to_js : enum_int -> Ojs.t =
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
     | Enum_int_other x2 -> Ojs.int_to_js x2
+type enum_float =
+  | Enum_float_0_1 
+  | Enum_float_1_1 
+  | Enum_float_other of float 
+let rec enum_float_of_js : Ojs.t -> enum_float =
+  fun (x8 : Ojs.t) ->
+    let x9 = x8 in
+    match Ojs.float_of_js x9 with
+    | 0.1 -> Enum_float_0_1
+    | 1.1 -> Enum_float_1_1
+    | x10 -> Enum_float_other x10
+and enum_float_to_js : enum_float -> Ojs.t =
+  fun (x6 : enum_float) ->
+    match x6 with
+    | Enum_float_0_1 -> Ojs.float_to_js 0.1
+    | Enum_float_1_1 -> Ojs.float_to_js 1.1
+    | Enum_float_other x7 -> Ojs.float_to_js x7
+type enum_number =
+  | Enum_number_0 
+  | Enum_number_1 
+  | Enum_number_0_1 
+  | Enum_number_1_1 
+  | Enum_number_other of float 
+let rec enum_number_of_js : Ojs.t -> enum_number =
+  fun (x13 : Ojs.t) ->
+    let x14 = x13 in
+    match Ojs.int_of_js x14 with
+    | 0 -> Enum_number_0
+    | 1 -> Enum_number_1
+    | _ ->
+        (match Ojs.float_of_js x14 with
+         | 0.1 -> Enum_number_0_1
+         | 1.1 -> Enum_number_1_1
+         | x15 -> Enum_number_other x15)
+and enum_number_to_js : enum_number -> Ojs.t =
+  fun (x11 : enum_number) ->
+    match x11 with
+    | Enum_number_0 -> Ojs.int_to_js 0
+    | Enum_number_1 -> Ojs.int_to_js 1
+    | Enum_number_0_1 -> Ojs.float_to_js 0.1
+    | Enum_number_1_1 -> Ojs.float_to_js 1.1
+    | Enum_number_other x12 -> Ojs.float_to_js x12
 type enum_string =
   | Enum_string_foo 
   | Enum_string_bar 
   | Enum_string_other of string 
 let rec enum_string_of_js : Ojs.t -> enum_string =
-  fun (x8 : Ojs.t) ->
-    let x9 = x8 in
-    match Ojs.string_of_js x9 with
+  fun (x18 : Ojs.t) ->
+    let x19 = x18 in
+    match Ojs.string_of_js x19 with
     | "foo" -> Enum_string_foo
     | "bar" -> Enum_string_bar
-    | x10 -> Enum_string_other x10
+    | x20 -> Enum_string_other x20
 and enum_string_to_js : enum_string -> Ojs.t =
-  fun (x6 : enum_string) ->
-    match x6 with
+  fun (x16 : enum_string) ->
+    match x16 with
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x7 -> Ojs.string_to_js x7
+    | Enum_string_other x17 -> Ojs.string_to_js x17
 type enum_bool =
   | Enum_bool_true 
   | Enum_bool_false 
 let rec enum_bool_of_js : Ojs.t -> enum_bool =
-  fun (x12 : Ojs.t) ->
-    let x13 = x12 in
-    match Ojs.bool_of_js x13 with
+  fun (x22 : Ojs.t) ->
+    let x23 = x22 in
+    match Ojs.bool_of_js x23 with
     | true -> Enum_bool_true
     | false -> Enum_bool_false
 and enum_bool_to_js : enum_bool -> Ojs.t =
-  fun (x11 : enum_bool) ->
-    match x11 with
+  fun (x21 : enum_bool) ->
+    match x21 with
     | Enum_bool_true -> Ojs.bool_to_js true
     | Enum_bool_false -> Ojs.bool_to_js false
 type enum_bool_partial =
   | Enum_bool_true 
 let rec enum_bool_partial_of_js : Ojs.t -> enum_bool_partial =
-  fun (x15 : Ojs.t) ->
-    let x16 = x15 in
-    match Ojs.bool_of_js x16 with
+  fun (x25 : Ojs.t) ->
+    let x26 = x25 in
+    match Ojs.bool_of_js x26 with
     | true -> Enum_bool_true
     | _ -> assert false
 and enum_bool_partial_to_js : enum_bool_partial -> Ojs.t =
-  fun (x14 : enum_bool_partial) ->
-    match x14 with | Enum_bool_true -> Ojs.bool_to_js true
+  fun (x24 : enum_bool_partial) ->
+    match x24 with | Enum_bool_true -> Ojs.bool_to_js true
 type enum_bool_partial2 =
   | Enum_bool_true 
   | Enum_bool_other of bool 
 let rec enum_bool_partial2_of_js : Ojs.t -> enum_bool_partial2 =
-  fun (x19 : Ojs.t) ->
-    let x20 = x19 in
-    match Ojs.bool_of_js x20 with
+  fun (x29 : Ojs.t) ->
+    let x30 = x29 in
+    match Ojs.bool_of_js x30 with
     | true -> Enum_bool_true
-    | x21 -> Enum_bool_other x21
+    | x31 -> Enum_bool_other x31
 and enum_bool_partial2_to_js : enum_bool_partial2 -> Ojs.t =
-  fun (x17 : enum_bool_partial2) ->
-    match x17 with
+  fun (x27 : enum_bool_partial2) ->
+    match x27 with
     | Enum_bool_true -> Ojs.bool_to_js true
-    | Enum_bool_other x18 -> Ojs.bool_to_js x18
+    | Enum_bool_other x28 -> Ojs.bool_to_js x28
 type enum_mixed =
   | Enum_int_0 
   | Enum_int_1 
-  | Enum_int_other of int 
+  | Enum_float_0_1 
+  | Enum_float_1_1 
+  | Enum_number_other of int 
   | Enum_string_foo 
   | Enum_string_bar 
   | Enum_string_other of string 
   | Enum_bool_true 
   | Enum_bool_false 
 let rec enum_mixed_of_js : Ojs.t -> enum_mixed =
-  fun (x25 : Ojs.t) ->
-    let x26 = x25 in
-    match Ojs.type_of x26 with
+  fun (x35 : Ojs.t) ->
+    let x36 = x35 in
+    match Ojs.type_of x36 with
     | "number" ->
-        (match Ojs.int_of_js x26 with
-         | 0 -> Enum_int_0
-         | 1 -> Enum_int_1
-         | x27 -> Enum_int_other x27)
+        (match Ojs.float_of_js x36 with
+         | 0.1 -> Enum_float_0_1
+         | 1.1 -> Enum_float_1_1
+         | _ ->
+             (match Ojs.int_of_js x36 with
+              | 0 -> Enum_int_0
+              | 1 -> Enum_int_1
+              | x37 -> Enum_number_other x37))
     | "string" ->
-        (match Ojs.string_of_js x26 with
+        (match Ojs.string_of_js x36 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x28 -> Enum_string_other x28)
+         | x38 -> Enum_string_other x38)
     | "boolean" ->
-        (match Ojs.bool_of_js x26 with
+        (match Ojs.bool_of_js x36 with
          | true -> Enum_bool_true
          | false -> Enum_bool_false)
     | _ -> assert false
 and enum_mixed_to_js : enum_mixed -> Ojs.t =
-  fun (x22 : enum_mixed) ->
-    match x22 with
+  fun (x32 : enum_mixed) ->
+    match x32 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
-    | Enum_int_other x23 -> Ojs.int_to_js x23
+    | Enum_float_0_1 -> Ojs.float_to_js 0.1
+    | Enum_float_1_1 -> Ojs.float_to_js 1.1
+    | Enum_number_other x33 -> Ojs.int_to_js x33
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x24 -> Ojs.string_to_js x24
+    | Enum_string_other x34 -> Ojs.string_to_js x34
     | Enum_bool_true -> Ojs.bool_to_js true
     | Enum_bool_false -> Ojs.bool_to_js false
 type enum_mixed_partial_bool =
   | Enum_int_0 
   | Enum_int_1 
-  | Enum_int_other of int 
+  | Enum_float_0_1 
+  | Enum_float_1_1 
+  | Enum_number_other of float 
   | Enum_string_foo 
   | Enum_string_bar 
   | Enum_string_other of string 
   | Enum_bool_true 
 let rec enum_mixed_partial_bool_of_js : Ojs.t -> enum_mixed_partial_bool =
-  fun (x32 : Ojs.t) ->
-    let x33 = x32 in
-    match Ojs.type_of x33 with
+  fun (x42 : Ojs.t) ->
+    let x43 = x42 in
+    match Ojs.type_of x43 with
     | "number" ->
-        (match Ojs.int_of_js x33 with
+        (match Ojs.int_of_js x43 with
          | 0 -> Enum_int_0
          | 1 -> Enum_int_1
-         | x34 -> Enum_int_other x34)
+         | _ ->
+             (match Ojs.float_of_js x43 with
+              | 0.1 -> Enum_float_0_1
+              | 1.1 -> Enum_float_1_1
+              | x44 -> Enum_number_other x44))
     | "string" ->
-        (match Ojs.string_of_js x33 with
+        (match Ojs.string_of_js x43 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x35 -> Enum_string_other x35)
+         | x45 -> Enum_string_other x45)
     | "boolean" ->
-        (match Ojs.bool_of_js x33 with
+        (match Ojs.bool_of_js x43 with
          | true -> Enum_bool_true
          | _ -> assert false)
     | _ -> assert false
 and enum_mixed_partial_bool_to_js : enum_mixed_partial_bool -> Ojs.t =
-  fun (x29 : enum_mixed_partial_bool) ->
-    match x29 with
+  fun (x39 : enum_mixed_partial_bool) ->
+    match x39 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
-    | Enum_int_other x30 -> Ojs.int_to_js x30
+    | Enum_float_0_1 -> Ojs.float_to_js 0.1
+    | Enum_float_1_1 -> Ojs.float_to_js 1.1
+    | Enum_number_other x40 -> Ojs.float_to_js x40
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x31 -> Ojs.string_to_js x31
+    | Enum_string_other x41 -> Ojs.string_to_js x41
     | Enum_bool_true -> Ojs.bool_to_js true
 type enum_mixed_partial_bool2 =
   | Enum_int_0 
   | Enum_int_1 
-  | Enum_int_other of int 
+  | Enum_float_0_1 
+  | Enum_float_1_1 
+  | Enum_number_other of float 
   | Enum_string_foo 
   | Enum_string_bar 
   | Enum_string_other of string 
   | Enum_bool_true 
   | Enum_bool_other of bool 
 let rec enum_mixed_partial_bool2_of_js : Ojs.t -> enum_mixed_partial_bool2 =
-  fun (x40 : Ojs.t) ->
-    let x41 = x40 in
-    match Ojs.type_of x41 with
+  fun (x50 : Ojs.t) ->
+    let x51 = x50 in
+    match Ojs.type_of x51 with
     | "number" ->
-        (match Ojs.int_of_js x41 with
+        (match Ojs.int_of_js x51 with
          | 0 -> Enum_int_0
          | 1 -> Enum_int_1
-         | x42 -> Enum_int_other x42)
+         | _ ->
+             (match Ojs.float_of_js x51 with
+              | 0.1 -> Enum_float_0_1
+              | 1.1 -> Enum_float_1_1
+              | x52 -> Enum_number_other x52))
     | "string" ->
-        (match Ojs.string_of_js x41 with
+        (match Ojs.string_of_js x51 with
          | "foo" -> Enum_string_foo
          | "bar" -> Enum_string_bar
-         | x43 -> Enum_string_other x43)
+         | x53 -> Enum_string_other x53)
     | "boolean" ->
-        (match Ojs.bool_of_js x41 with
+        (match Ojs.bool_of_js x51 with
          | true -> Enum_bool_true
-         | x44 -> Enum_bool_other x44)
+         | x54 -> Enum_bool_other x54)
     | _ -> assert false
 and enum_mixed_partial_bool2_to_js : enum_mixed_partial_bool2 -> Ojs.t =
-  fun (x36 : enum_mixed_partial_bool2) ->
-    match x36 with
+  fun (x46 : enum_mixed_partial_bool2) ->
+    match x46 with
     | Enum_int_0 -> Ojs.int_to_js 0
     | Enum_int_1 -> Ojs.int_to_js 1
-    | Enum_int_other x37 -> Ojs.int_to_js x37
+    | Enum_float_0_1 -> Ojs.float_to_js 0.1
+    | Enum_float_1_1 -> Ojs.float_to_js 1.1
+    | Enum_number_other x47 -> Ojs.float_to_js x47
     | Enum_string_foo -> Ojs.string_to_js "foo"
     | Enum_string_bar -> Ojs.string_to_js "bar"
-    | Enum_string_other x38 -> Ojs.string_to_js x38
+    | Enum_string_other x48 -> Ojs.string_to_js x48
     | Enum_bool_true -> Ojs.bool_to_js true
-    | Enum_bool_other x39 -> Ojs.bool_to_js x39
+    | Enum_bool_other x49 -> Ojs.bool_to_js x49
 type dummy1 = Ojs.t
-let rec dummy1_of_js : Ojs.t -> dummy1 = fun (x46 : Ojs.t) -> x46
-and dummy1_to_js : dummy1 -> Ojs.t = fun (x45 : Ojs.t) -> x45
+let rec dummy1_of_js : Ojs.t -> dummy1 = fun (x56 : Ojs.t) -> x56
+and dummy1_to_js : dummy1 -> Ojs.t = fun (x55 : Ojs.t) -> x55
 type dummy2 = Ojs.t
-let rec dummy2_of_js : Ojs.t -> dummy2 = fun (x48 : Ojs.t) -> x48
-and dummy2_to_js : dummy2 -> Ojs.t = fun (x47 : Ojs.t) -> x47
+let rec dummy2_of_js : Ojs.t -> dummy2 = fun (x58 : Ojs.t) -> x58
+and dummy2_to_js : dummy2 -> Ojs.t = fun (x57 : Ojs.t) -> x57
 type dummy3 = Ojs.t
-let rec dummy3_of_js : Ojs.t -> dummy3 = fun (x50 : Ojs.t) -> x50
-and dummy3_to_js : dummy3 -> Ojs.t = fun (x49 : Ojs.t) -> x49
+let rec dummy3_of_js : Ojs.t -> dummy3 = fun (x60 : Ojs.t) -> x60
+and dummy3_to_js : dummy3 -> Ojs.t = fun (x59 : Ojs.t) -> x59
 type dummy4 = Ojs.t
-let rec dummy4_of_js : Ojs.t -> dummy4 = fun (x52 : Ojs.t) -> x52
-and dummy4_to_js : dummy4 -> Ojs.t = fun (x51 : Ojs.t) -> x51
+let rec dummy4_of_js : Ojs.t -> dummy4 = fun (x62 : Ojs.t) -> x62
+and dummy4_to_js : dummy4 -> Ojs.t = fun (x61 : Ojs.t) -> x61
 type dummy5 = Ojs.t
-let rec dummy5_of_js : Ojs.t -> dummy5 = fun (x54 : Ojs.t) -> x54
-and dummy5_to_js : dummy5 -> Ojs.t = fun (x53 : Ojs.t) -> x53
+let rec dummy5_of_js : Ojs.t -> dummy5 = fun (x64 : Ojs.t) -> x64
+and dummy5_to_js : dummy5 -> Ojs.t = fun (x63 : Ojs.t) -> x63
 type dummy6 = Ojs.t
-let rec dummy6_of_js : Ojs.t -> dummy6 = fun (x56 : Ojs.t) -> x56
-and dummy6_to_js : dummy6 -> Ojs.t = fun (x55 : Ojs.t) -> x55
+let rec dummy6_of_js : Ojs.t -> dummy6 = fun (x66 : Ojs.t) -> x66
+and dummy6_to_js : dummy6 -> Ojs.t = fun (x65 : Ojs.t) -> x65
 type union_int =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
   | Unknown of Ojs.t 
 let rec union_int_of_js : Ojs.t -> union_int =
-  fun (x61 : Ojs.t) ->
-    let x62 = x61 in
-    match Ojs.type_of (Ojs.get_prop_ascii x62 "tag") with
+  fun (x71 : Ojs.t) ->
+    let x72 = x71 in
+    match Ojs.type_of (Ojs.get_prop_ascii x72 "tag") with
     | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x62 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x62)
-         | 1 -> Union_int_1 (dummy2_of_js x62)
-         | _ -> Unknown x62)
-    | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x62 "tag") with
-         | _ -> Unknown x62)
-    | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x62 "tag") with
-         | _ -> Unknown x62)
-    | _ -> Unknown x62
+        (match Ojs.int_of_js (Ojs.get_prop_ascii x72 "tag") with
+         | 0 -> Union_int_0 (dummy1_of_js x72)
+         | 1 -> Union_int_1 (dummy2_of_js x72)
+         | _ -> Unknown x72)
+    | "string" -> Unknown x72
+    | "boolean" -> Unknown x72
+    | _ -> Unknown x72
 and union_int_to_js : union_int -> Ojs.t =
-  fun (x57 : union_int) ->
-    match x57 with
-    | Union_int_0 x58 -> dummy1_to_js x58
-    | Union_int_1 x59 -> dummy2_to_js x59
-    | Unknown x60 -> x60
+  fun (x67 : union_int) ->
+    match x67 with
+    | Union_int_0 x68 -> dummy1_to_js x68
+    | Union_int_1 x69 -> dummy2_to_js x69
+    | Unknown x70 -> x70
+type union_float =
+  | Union_float_0_1 of dummy1 
+  | Union_float_1_1 of dummy1 
+  | Unknown of Ojs.t 
+let rec union_float_of_js : Ojs.t -> union_float =
+  fun (x77 : Ojs.t) ->
+    let x78 = x77 in
+    match Ojs.type_of (Ojs.get_prop_ascii x78 "tag") with
+    | "string" -> Unknown x78
+    | "boolean" -> Unknown x78
+    | _ -> Unknown x78
+and union_float_to_js : union_float -> Ojs.t =
+  fun (x73 : union_float) ->
+    match x73 with
+    | Union_float_0_1 x74 -> dummy1_to_js x74
+    | Union_float_1_1 x75 -> dummy1_to_js x75
+    | Unknown x76 -> x76
 type union_string =
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Unknown of Ojs.t 
 let rec union_string_of_js : Ojs.t -> union_string =
-  fun (x67 : Ojs.t) ->
-    let x68 = x67 in
-    match Ojs.type_of (Ojs.get_prop_ascii x68 "tag") with
-    | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x68 "tag") with
-         | _ -> Unknown x68)
+  fun (x83 : Ojs.t) ->
+    let x84 = x83 in
+    match Ojs.type_of (Ojs.get_prop_ascii x84 "tag") with
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x68 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x68)
-         | "bar" -> Union_string_bar (dummy4_of_js x68)
-         | _ -> Unknown x68)
-    | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x68 "tag") with
-         | _ -> Unknown x68)
-    | _ -> Unknown x68
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x84 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x84)
+         | "bar" -> Union_string_bar (dummy4_of_js x84)
+         | _ -> Unknown x84)
+    | "boolean" -> Unknown x84
+    | _ -> Unknown x84
 and union_string_to_js : union_string -> Ojs.t =
-  fun (x63 : union_string) ->
-    match x63 with
-    | Union_string_foo x64 -> dummy3_to_js x64
-    | Union_string_bar x65 -> dummy4_to_js x65
-    | Unknown x66 -> x66
+  fun (x79 : union_string) ->
+    match x79 with
+    | Union_string_foo x80 -> dummy3_to_js x80
+    | Union_string_bar x81 -> dummy4_to_js x81
+    | Unknown x82 -> x82
 type union_bool =
   | Union_bool_true of dummy5 
   | Union_bool_false of dummy6 
 let rec union_bool_of_js : Ojs.t -> union_bool =
-  fun (x72 : Ojs.t) ->
-    let x73 = x72 in
-    match Ojs.bool_of_js (Ojs.get_prop_ascii x73 "tag") with
-    | true -> Union_bool_true (dummy5_of_js x73)
-    | false -> Union_bool_false (dummy6_of_js x73)
+  fun (x88 : Ojs.t) ->
+    let x89 = x88 in
+    match Ojs.bool_of_js (Ojs.get_prop_ascii x89 "tag") with
+    | true -> Union_bool_true (dummy5_of_js x89)
+    | false -> Union_bool_false (dummy6_of_js x89)
 and union_bool_to_js : union_bool -> Ojs.t =
-  fun (x69 : union_bool) ->
-    match x69 with
-    | Union_bool_true x70 -> dummy5_to_js x70
-    | Union_bool_false x71 -> dummy6_to_js x71
+  fun (x85 : union_bool) ->
+    match x85 with
+    | Union_bool_true x86 -> dummy5_to_js x86
+    | Union_bool_false x87 -> dummy6_to_js x87
 type union_bool_partial =
   | Union_bool_true of dummy5 
 let rec union_bool_partial_of_js : Ojs.t -> union_bool_partial =
-  fun (x76 : Ojs.t) ->
-    let x77 = x76 in
-    match Ojs.bool_of_js (Ojs.get_prop_ascii x77 "tag") with
-    | true -> Union_bool_true (dummy5_of_js x77)
+  fun (x92 : Ojs.t) ->
+    let x93 = x92 in
+    match Ojs.bool_of_js (Ojs.get_prop_ascii x93 "tag") with
+    | true -> Union_bool_true (dummy5_of_js x93)
     | _ -> assert false
 and union_bool_partial_to_js : union_bool_partial -> Ojs.t =
-  fun (x74 : union_bool_partial) ->
-    match x74 with | Union_bool_true x75 -> dummy5_to_js x75
+  fun (x90 : union_bool_partial) ->
+    match x90 with | Union_bool_true x91 -> dummy5_to_js x91
 type union_bool_partial2 =
   | Union_bool_true of dummy5 
   | Unknown of Ojs.t 
 let rec union_bool_partial2_of_js : Ojs.t -> union_bool_partial2 =
-  fun (x81 : Ojs.t) ->
-    let x82 = x81 in
-    match Ojs.type_of (Ojs.get_prop_ascii x82 "tag") with
-    | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x82 "tag") with
-         | _ -> Unknown x82)
-    | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x82 "tag") with
-         | _ -> Unknown x82)
+  fun (x97 : Ojs.t) ->
+    let x98 = x97 in
+    match Ojs.type_of (Ojs.get_prop_ascii x98 "tag") with
+    | "string" -> Unknown x98
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x82 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x82)
-         | _ -> Unknown x82)
-    | _ -> Unknown x82
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x98 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x98)
+         | _ -> Unknown x98)
+    | _ -> Unknown x98
 and union_bool_partial2_to_js : union_bool_partial2 -> Ojs.t =
-  fun (x78 : union_bool_partial2) ->
-    match x78 with
-    | Union_bool_true x79 -> dummy5_to_js x79
-    | Unknown x80 -> x80
+  fun (x94 : union_bool_partial2) ->
+    match x94 with
+    | Union_bool_true x95 -> dummy5_to_js x95
+    | Unknown x96 -> x96
 type union_mixed =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
+  | Union_float_0_1 of dummy1 
+  | Union_float_1_1 of dummy1 
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Union_bool_true of dummy5 
   | Union_bool_false of dummy6 
   | Unknown of Ojs.t 
 let rec union_mixed_of_js : Ojs.t -> union_mixed =
-  fun (x91 : Ojs.t) ->
-    let x92 = x91 in
-    match Ojs.type_of (Ojs.get_prop_ascii x92 "tag") with
+  fun (x109 : Ojs.t) ->
+    let x110 = x109 in
+    match Ojs.type_of (Ojs.get_prop_ascii x110 "tag") with
     | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x92 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x92)
-         | 1 -> Union_int_1 (dummy2_of_js x92)
-         | _ -> Unknown x92)
+        (match Ojs.int_of_js (Ojs.get_prop_ascii x110 "tag") with
+         | 0 -> Union_int_0 (dummy1_of_js x110)
+         | 1 -> Union_int_1 (dummy2_of_js x110)
+         | _ ->
+             (match Ojs.float_of_js (Ojs.get_prop_ascii x110 "tag") with
+              | 0.1 -> Union_float_0_1 (dummy1_of_js x110)
+              | 1.1 -> Union_float_1_1 (dummy1_of_js x110)
+              | _ -> Unknown x110))
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x92 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x92)
-         | "bar" -> Union_string_bar (dummy4_of_js x92)
-         | _ -> Unknown x92)
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x110 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x110)
+         | "bar" -> Union_string_bar (dummy4_of_js x110)
+         | _ -> Unknown x110)
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x92 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x92)
-         | false -> Union_bool_false (dummy6_of_js x92))
-    | _ -> Unknown x92
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x110 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x110)
+         | false -> Union_bool_false (dummy6_of_js x110))
+    | _ -> Unknown x110
 and union_mixed_to_js : union_mixed -> Ojs.t =
-  fun (x83 : union_mixed) ->
-    match x83 with
-    | Union_int_0 x84 -> dummy1_to_js x84
-    | Union_int_1 x85 -> dummy2_to_js x85
-    | Union_string_foo x86 -> dummy3_to_js x86
-    | Union_string_bar x87 -> dummy4_to_js x87
-    | Union_bool_true x88 -> dummy5_to_js x88
-    | Union_bool_false x89 -> dummy6_to_js x89
-    | Unknown x90 -> x90
+  fun (x99 : union_mixed) ->
+    match x99 with
+    | Union_int_0 x100 -> dummy1_to_js x100
+    | Union_int_1 x101 -> dummy2_to_js x101
+    | Union_float_0_1 x102 -> dummy1_to_js x102
+    | Union_float_1_1 x103 -> dummy1_to_js x103
+    | Union_string_foo x104 -> dummy3_to_js x104
+    | Union_string_bar x105 -> dummy4_to_js x105
+    | Union_bool_true x106 -> dummy5_to_js x106
+    | Union_bool_false x107 -> dummy6_to_js x107
+    | Unknown x108 -> x108
 type union_mixed_partial_bool =
   | Union_int_0 of dummy1 
   | Union_int_1 of dummy2 
+  | Union_float_0_1 of dummy1 
+  | Union_float_1_1 of dummy1 
   | Union_string_foo of dummy3 
   | Union_string_bar of dummy4 
   | Union_bool_true of dummy5 
   | Unknown of Ojs.t 
 let rec union_mixed_partial_bool_of_js : Ojs.t -> union_mixed_partial_bool =
-  fun (x100 : Ojs.t) ->
-    let x101 = x100 in
-    match Ojs.type_of (Ojs.get_prop_ascii x101 "tag") with
+  fun (x120 : Ojs.t) ->
+    let x121 = x120 in
+    match Ojs.type_of (Ojs.get_prop_ascii x121 "tag") with
     | "number" ->
-        (match Ojs.int_of_js (Ojs.get_prop_ascii x101 "tag") with
-         | 0 -> Union_int_0 (dummy1_of_js x101)
-         | 1 -> Union_int_1 (dummy2_of_js x101)
-         | _ -> Unknown x101)
+        (match Ojs.int_of_js (Ojs.get_prop_ascii x121 "tag") with
+         | 0 -> Union_int_0 (dummy1_of_js x121)
+         | 1 -> Union_int_1 (dummy2_of_js x121)
+         | _ ->
+             (match Ojs.float_of_js (Ojs.get_prop_ascii x121 "tag") with
+              | 0.1 -> Union_float_0_1 (dummy1_of_js x121)
+              | 1.1 -> Union_float_1_1 (dummy1_of_js x121)
+              | _ -> Unknown x121))
     | "string" ->
-        (match Ojs.string_of_js (Ojs.get_prop_ascii x101 "tag") with
-         | "foo" -> Union_string_foo (dummy3_of_js x101)
-         | "bar" -> Union_string_bar (dummy4_of_js x101)
-         | _ -> Unknown x101)
+        (match Ojs.string_of_js (Ojs.get_prop_ascii x121 "tag") with
+         | "foo" -> Union_string_foo (dummy3_of_js x121)
+         | "bar" -> Union_string_bar (dummy4_of_js x121)
+         | _ -> Unknown x121)
     | "boolean" ->
-        (match Ojs.bool_of_js (Ojs.get_prop_ascii x101 "tag") with
-         | true -> Union_bool_true (dummy5_of_js x101)
-         | _ -> Unknown x101)
-    | _ -> Unknown x101
+        (match Ojs.bool_of_js (Ojs.get_prop_ascii x121 "tag") with
+         | true -> Union_bool_true (dummy5_of_js x121)
+         | _ -> Unknown x121)
+    | _ -> Unknown x121
 and union_mixed_partial_bool_to_js : union_mixed_partial_bool -> Ojs.t =
-  fun (x93 : union_mixed_partial_bool) ->
-    match x93 with
-    | Union_int_0 x94 -> dummy1_to_js x94
-    | Union_int_1 x95 -> dummy2_to_js x95
-    | Union_string_foo x96 -> dummy3_to_js x96
-    | Union_string_bar x97 -> dummy4_to_js x97
-    | Union_bool_true x98 -> dummy5_to_js x98
-    | Unknown x99 -> x99
+  fun (x111 : union_mixed_partial_bool) ->
+    match x111 with
+    | Union_int_0 x112 -> dummy1_to_js x112
+    | Union_int_1 x113 -> dummy2_to_js x113
+    | Union_float_0_1 x114 -> dummy1_to_js x114
+    | Union_float_1_1 x115 -> dummy1_to_js x115
+    | Union_string_foo x116 -> dummy3_to_js x116
+    | Union_string_bar x117 -> dummy4_to_js x117
+    | Union_bool_true x118 -> dummy5_to_js x118
+    | Unknown x119 -> x119

--- a/ppx-test/types.ml
+++ b/ppx-test/types.ml
@@ -84,17 +84,19 @@ module T  = [%js:
     type enum =
       | Foo [@js "foo"]
       | Bar [@js 42]
-      | Baz
+      | Baz [@js 4.2]
+      | Qux
         [@@js.enum]
 
     type status =
     | OK [@js 1]
     | KO [@js 2]
+    | OO [@js 1.5]
     | OtherS of string [@js.default]
     | OtherI of int [@js.default]
       [@@js.enum]
 
-    type poly = [`foo | `bar [@js 42] | `Baz | `I of int [@js.default] | `S of string[@js.default] ] [@js.enum]
+    type poly = [`foo | `bar [@js 42] | `Baz | `I of int [@js.default] | `S of string[@js.default]] [@js.enum]
 
     type sum =
         | A

--- a/ppx-test/types.ml
+++ b/ppx-test/types.ml
@@ -96,7 +96,7 @@ module T  = [%js:
     | OtherI of int [@js.default]
       [@@js.enum]
 
-    type poly = [`foo | `bar [@js 42] | `Baz | `I of int [@js.default] | `S of string[@js.default]] [@js.enum]
+    type poly = [`foo | `bar [@js 42] | `baz [@js 4.2] | `Qux | `I of int [@js.default] | `S of string[@js.default]] [@js.enum]
 
     type sum =
         | A

--- a/ppx-test/union_and_enum.mli
+++ b/ppx-test/union_and_enum.mli
@@ -10,12 +10,22 @@ type enum_float =
   | Enum_float_other of float [@js.default]
   [@@js.enum]
 
-type enum_number =
+(* float cases should be matched first *)
+type enum_number_1 =
   | Enum_number_0 [@js 0]
   | Enum_number_1 [@js 1]
   | Enum_number_0_1 [@js 0.1]
   | Enum_number_1_1 [@js 1.1]
   | Enum_number_other of float [@js.default]
+  [@@js.enum]
+
+(* float cases should be matched first even if the default case is int*)
+type enum_number_2 =
+  | Enum_number_0 [@js 0]
+  | Enum_number_1 [@js 1]
+  | Enum_number_0_1 [@js 0.1]
+  | Enum_number_1_1 [@js 1.1]
+  | Enum_number_other of int [@js.default]
   [@@js.enum]
 
 type enum_string =

--- a/ppx-test/union_and_enum.mli
+++ b/ppx-test/union_and_enum.mli
@@ -4,6 +4,20 @@ type enum_int =
   | Enum_int_other of int [@js.default]
   [@@js.enum]
 
+type enum_float =
+  | Enum_float_0_1 [@js 0.1]
+  | Enum_float_1_1 [@js 1.1]
+  | Enum_float_other of float [@js.default]
+  [@@js.enum]
+
+type enum_number =
+  | Enum_number_0 [@js 0]
+  | Enum_number_1 [@js 1]
+  | Enum_number_0_1 [@js 0.1]
+  | Enum_number_1_1 [@js 1.1]
+  | Enum_number_other of float [@js.default]
+  [@@js.enum]
+
 type enum_string =
   | Enum_string_foo [@js "foo"]
   | Enum_string_bar [@js "bar"]
@@ -31,7 +45,9 @@ type enum_bool_partial2 =
 type enum_mixed =
   | Enum_int_0 [@js 0]
   | Enum_int_1 [@js 1]
-  | Enum_int_other of int [@js.default]
+  | Enum_float_0_1 [@js 0.1]
+  | Enum_float_1_1 [@js 1.1]
+  | Enum_number_other of int [@js.default]
   | Enum_string_foo [@js "foo"]
   | Enum_string_bar [@js "bar"]
   | Enum_string_other of string [@js.default]
@@ -43,7 +59,9 @@ type enum_mixed =
 type enum_mixed_partial_bool =
   | Enum_int_0 [@js 0]
   | Enum_int_1 [@js 1]
-  | Enum_int_other of int [@js.default]
+  | Enum_float_0_1 [@js 0.1]
+  | Enum_float_1_1 [@js 1.1]
+  | Enum_number_other of float [@js.default]
   | Enum_string_foo [@js "foo"]
   | Enum_string_bar [@js "bar"]
   | Enum_string_other of string [@js.default]
@@ -54,7 +72,9 @@ type enum_mixed_partial_bool =
 type enum_mixed_partial_bool2 =
   | Enum_int_0 [@js 0]
   | Enum_int_1 [@js 1]
-  | Enum_int_other of int [@js.default]
+  | Enum_float_0_1 [@js 0.1]
+  | Enum_float_1_1 [@js 1.1]
+  | Enum_number_other of float [@js.default]
   | Enum_string_foo [@js "foo"]
   | Enum_string_bar [@js "bar"]
   | Enum_string_other of string [@js.default]
@@ -72,6 +92,12 @@ type dummy6
 type union_int =
   | Union_int_0 of dummy1 [@js 0]
   | Union_int_1 of dummy2 [@js 1]
+  | Unknown of Ojs.t [@js.default]
+  [@@js.union on_field "tag"]
+
+type union_float =
+  | Union_float_0_1 of dummy1 [@js 0.1]
+  | Union_float_1_1 of dummy1 [@js 1.1]
   | Unknown of Ojs.t [@js.default]
   [@@js.union on_field "tag"]
 
@@ -102,6 +128,8 @@ type union_bool_partial2 =
 type union_mixed =
   | Union_int_0 of dummy1 [@js 0]
   | Union_int_1 of dummy2 [@js 1]
+  | Union_float_0_1 of dummy1 [@js 0.1]
+  | Union_float_1_1 of dummy1 [@js 1.1]
   | Union_string_foo of dummy3 [@js "foo"]
   | Union_string_bar of dummy4 [@js "bar"]
   | Union_bool_true of dummy5 [@js true]
@@ -113,6 +141,8 @@ type union_mixed =
 type union_mixed_partial_bool =
   | Union_int_0 of dummy1 [@js 0]
   | Union_int_1 of dummy2 [@js 1]
+  | Union_float_0_1 of dummy1 [@js 0.1]
+  | Union_float_1_1 of dummy1 [@js 1.1]
   | Union_string_foo of dummy3 [@js "foo"]
   | Union_string_bar of dummy4 [@js "bar"]
   | Union_bool_true of dummy5 [@js true]

--- a/ppx-test/union_and_enum.mli
+++ b/ppx-test/union_and_enum.mli
@@ -16,16 +16,16 @@ type enum_number_1 =
   | Enum_number_1 [@js 1]
   | Enum_number_0_1 [@js 0.1]
   | Enum_number_1_1 [@js 1.1]
-  | Enum_number_other of float [@js.default]
+  | Enum_number_other of int [@js.default]
   [@@js.enum]
 
-(* float cases should be matched first even if the default case is int*)
+(* float cases should be matched first even if the default case is float *)
 type enum_number_2 =
   | Enum_number_0 [@js 0]
   | Enum_number_1 [@js 1]
   | Enum_number_0_1 [@js 0.1]
   | Enum_number_1_1 [@js 1.1]
-  | Enum_number_other of int [@js.default]
+  | Enum_number_other of float [@js.default]
   [@@js.enum]
 
 type enum_string =
@@ -107,7 +107,7 @@ type union_int =
 
 type union_float =
   | Union_float_0_1 of dummy1 [@js 0.1]
-  | Union_float_1_1 of dummy1 [@js 1.1]
+  | Union_float_1_1 of dummy2 [@js 1.1]
   | Unknown of Ojs.t [@js.default]
   [@@js.union on_field "tag"]
 
@@ -139,7 +139,7 @@ type union_mixed =
   | Union_int_0 of dummy1 [@js 0]
   | Union_int_1 of dummy2 [@js 1]
   | Union_float_0_1 of dummy1 [@js 0.1]
-  | Union_float_1_1 of dummy1 [@js 1.1]
+  | Union_float_1_1 of dummy2 [@js 1.1]
   | Union_string_foo of dummy3 [@js "foo"]
   | Union_string_bar of dummy4 [@js "bar"]
   | Union_bool_true of dummy5 [@js true]
@@ -152,7 +152,7 @@ type union_mixed_partial_bool =
   | Union_int_0 of dummy1 [@js 0]
   | Union_int_1 of dummy2 [@js 1]
   | Union_float_0_1 of dummy1 [@js 0.1]
-  | Union_float_1_1 of dummy1 [@js 1.1]
+  | Union_float_1_1 of dummy2 [@js 1.1]
   | Union_string_foo of dummy3 [@js "foo"]
   | Union_string_bar of dummy4 [@js "bar"]
   | Union_bool_true of dummy5 [@js true]


### PR DESCRIPTION
Related: https://github.com/ocsigen/ts2ocaml/issues/39
Closes #108.

This PR allows float values to be used inside `[@js]` attribute, which also allows binding to float enums and discriminated union using float value as a discriminator.

This PR also optimizes the generated `match` statements when they only have a default case with no binding.
```diff
  match Ojs.type_of (Ojs.get_prop_ascii x168 "kind") with
- | "number" ->
-    (match Ojs.int_of_js (Ojs.get_prop_ascii x168 "kind") with
-    | _ -> Unknown x168)
+ | "number" -> Unknown x168
```