### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,7 +37,8 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
-          dune-cache: true
+          opam-pin: false
+          dune-cache: ${{ matrix.os != 'windows-latest' }}
 
       - run: opam install . --deps-only --with-doc --with-test
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Upcoming 
+--------
+- GPR#167: Fix CI (@cannorin)
+
 Version 1.1.0
 -------------
 

--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@ gen_js_api is to be used with the js_of_ocaml compiler.
  (conflicts (js_of_ocaml-compiler (< 4.0.0)))
  (depends
   (ocaml (>= 4.08))
-  (ppxlib (>= 0.22))
+  (ppxlib (>= 0.26))
   (js_of_ocaml-compiler :with-test)
   (conf-npm :with-test)
   (ojs (= 1.1.0)))

--- a/gen_js_api.opam
+++ b/gen_js_api.opam
@@ -22,7 +22,7 @@ bug-reports: "https://github.com/LexiFi/gen_js_api/issues"
 depends: [
   "dune" {>= "2.7"}
   "ocaml" {>= "4.08"}
-  "ppxlib" {>= "0.22"}
+  "ppxlib" {>= "0.26"}
   "js_of_ocaml-compiler" {with-test}
   "conf-npm" {with-test}
   "ojs" {= "1.1.0"}

--- a/ppx-test/expected/issues.ml
+++ b/ppx-test/expected/issues.ml
@@ -55,11 +55,12 @@ module Issue124 :
       and b_of_js : Ojs.t -> b = fun js -> { a = (a_of_js js) }
       and b_to_js : b -> Ojs.t = fun { a } -> a_to_js a
       type 'a dummy = Ojs.t
-      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy = fun
-        (type __a) ->
-        fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
-      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t = fun (type
-        __a) -> fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
+      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy =
+        fun (type __a) ->
+          fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
+      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t =
+        fun (type __a) ->
+          fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
       type 'a wrapped =
         | Wrapped of 'a 
       let rec wrapped_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a wrapped =

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -410,42 +410,47 @@ module T :
       let rec parametrized_of_js :
         'a 'b .
           (Ojs.t -> 'a) -> (Ojs.t -> 'b) -> Ojs.t -> ('a, 'b) parametrized
-        = fun (type __a) -> fun (type __b) ->
-        fun (__a_of_js : Ojs.t -> __a) ->
-          fun (__b_of_js : Ojs.t -> __b) ->
-            fun (x130 : Ojs.t) ->
-              {
-                x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
-                y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
-              }
+        =
+        fun (type __a) ->
+          fun (type __b) ->
+            fun (__a_of_js : Ojs.t -> __a) ->
+              fun (__b_of_js : Ojs.t -> __b) ->
+                fun (x130 : Ojs.t) ->
+                  {
+                    x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
+                    y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
+                  }
       and parametrized_to_js :
         'a 'b .
           ('a -> Ojs.t) -> ('b -> Ojs.t) -> ('a, 'b) parametrized -> Ojs.t
-        = fun (type __a) -> fun (type __b) ->
-        fun (__a_to_js : __a -> Ojs.t) ->
-          fun (__b_to_js : __b -> Ojs.t) ->
-            fun (x129 : (__a, __b) parametrized) ->
-              Ojs.obj [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
+        =
+        fun (type __a) ->
+          fun (type __b) ->
+            fun (__a_to_js : __a -> Ojs.t) ->
+              fun (__b_to_js : __b -> Ojs.t) ->
+                fun (x129 : (__a, __b) parametrized) ->
+                  Ojs.obj
+                    [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
       type 'a abs = ('a -> int) -> unit
-      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs = fun (type
-        __a) ->
-        fun (__a_of_js : Ojs.t -> __a) ->
-          fun (x134 : Ojs.t) ->
-            fun (x135 : __a -> int) ->
-              ignore
-                (Ojs.apply x134
-                   [|(Ojs.fun_to_js 1
-                        (fun (x136 : Ojs.t) ->
-                           Ojs.int_to_js (x135 (__a_of_js x136))))|])
-      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t = fun (type __a)
-        ->
-        fun (__a_to_js : __a -> Ojs.t) ->
-          fun (x131 : (__a -> int) -> unit) ->
-            Ojs.fun_to_js 1
-              (fun (x132 : Ojs.t) ->
-                 x131
-                   (fun (x133 : __a) ->
-                      Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
+      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs =
+        fun (type __a) ->
+          fun (__a_of_js : Ojs.t -> __a) ->
+            fun (x134 : Ojs.t) ->
+              fun (x135 : __a -> int) ->
+                ignore
+                  (Ojs.apply x134
+                     [|(Ojs.fun_to_js 1
+                          (fun (x136 : Ojs.t) ->
+                             Ojs.int_to_js (x135 (__a_of_js x136))))|])
+      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t =
+        fun (type __a) ->
+          fun (__a_to_js : __a -> Ojs.t) ->
+            fun (x131 : (__a -> int) -> unit) ->
+              Ojs.fun_to_js 1
+                (fun (x132 : Ojs.t) ->
+                   x131
+                     (fun (x133 : __a) ->
+                        Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
       type specialized = (int, int) parametrized
       let rec specialized_of_js : Ojs.t -> specialized =
         fun (x140 : Ojs.t) ->


### PR DESCRIPTION
* Disables `opam-pin`.
* Disables `dune-cache` on Windows.
* Upgrades ppxlib to 0.26.
* Updates the expected test results with ppxlib 0.26.