### PR TITLE
Support tuple on @js.scope

### DIFF
--- a/node-test/bindings/expected/fs.ml
+++ b/node-test/bindings/expected/fs.ml
@@ -93,24 +93,27 @@ let (readdir : string -> string list Promise.t) =
   fun (x39 : string) ->
     Promise.t_of_js
       (fun (x40 : Ojs.t) -> Ojs.list_of_js Ojs.string_of_js x40)
-      (Ojs.call Imports.fs_promises "readdir" [|(Ojs.string_to_js x39)|])
+      (Ojs.call (Ojs.get_prop_ascii Imports.fs "promises") "readdir"
+         [|(Ojs.string_to_js x39)|])
 let (open_ : string -> flag:string -> FileHandle.t Promise.t) =
   fun (x42 : string) ->
     fun ~flag:(x43 : string) ->
       Promise.t_of_js FileHandle.t_of_js
-        (Ojs.call Imports.fs_promises "open"
+        (Ojs.call (Ojs.get_prop_ascii Imports.fs "promises") "open"
            [|(Ojs.string_to_js x42);(Ojs.string_to_js x43)|])
 let (rmdir : string -> unit Promise.t) =
   fun (x45 : string) ->
     Promise.t_of_js Ojs.unit_of_js
-      (Ojs.call Imports.fs_promises "rmdir" [|(Ojs.string_to_js x45)|])
+      (Ojs.call (Ojs.get_prop_ascii Imports.fs "promises") "rmdir"
+         [|(Ojs.string_to_js x45)|])
 let (rename : string -> string -> unit Promise.t) =
   fun (x47 : string) ->
     fun (x48 : string) ->
       Promise.t_of_js Ojs.unit_of_js
-        (Ojs.call Imports.fs_promises "rename"
+        (Ojs.call (Ojs.get_prop_ascii Imports.fs "promises") "rename"
            [|(Ojs.string_to_js x47);(Ojs.string_to_js x48)|])
 let (unlink : string -> unit Promise.t) =
   fun (x50 : string) ->
     Promise.t_of_js Ojs.unit_of_js
-      (Ojs.call Imports.fs_promises "unlink" [|(Ojs.string_to_js x50)|])
+      (Ojs.call (Ojs.get_prop_ascii Imports.fs "promises") "unlink"
+         [|(Ojs.string_to_js x50)|])

--- a/node-test/bindings/expected/imports.ml
+++ b/node-test/bindings/expected/imports.ml
@@ -3,6 +3,6 @@
 let (path : Ojs.t) =
   Ojs.get_prop_ascii (Ojs.get_prop_ascii Ojs.global "__LIB__NODE__IMPORTS")
     "path"
-let (fs_promises : Ojs.t) =
+let (fs : Ojs.t) =
   Ojs.get_prop_ascii (Ojs.get_prop_ascii Ojs.global "__LIB__NODE__IMPORTS")
-    "fsPromises"
+    "fs"

--- a/node-test/bindings/fs.mli
+++ b/node-test/bindings/fs.mli
@@ -1,4 +1,4 @@
-[@@@js.scope Imports.fs_promises]
+[@@@js.scope (Imports.fs, "promises")]
 
 module Dirent : sig
   type t = Ojs.t

--- a/node-test/bindings/imports.js
+++ b/node-test/bindings/imports.js
@@ -1,4 +1,4 @@
 joo_global_object.__LIB__NODE__IMPORTS = {
   path: require('path'),
-  fsPromises: require('fs').promises,
+  fs: require('fs'),
 };

--- a/node-test/bindings/imports.mli
+++ b/node-test/bindings/imports.mli
@@ -1,4 +1,4 @@
 [@@@js.scope "__LIB__NODE__IMPORTS"]
 
 val path: Ojs.t [@@js.global]
-val fs_promises: Ojs.t [@@js.global]
+val fs: Ojs.t [@@js.global]

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -1526,6 +1526,14 @@ let global_object ~global_attrs =
         begin match get_expr_attribute "js.scope" [hd] with
         | None -> traverse tl
         | Some {pexp_desc=Pexp_constant (Pconst_string (prop, _, _)); _} -> ojs_get (traverse tl) prop
+        | Some {pexp_desc=Pexp_tuple path; _} ->
+          let init = traverse tl in
+          let folder state pexp =
+            match pexp.pexp_desc with
+            | Pexp_constant (Pconst_string (prop, _, _)) -> ojs_get state prop
+            | _ -> pexp (* global object *)
+          in
+          List.fold_left folder init path
         | Some global_object -> global_object
         end
   in

--- a/ppx-test/expected/issues.ml
+++ b/ppx-test/expected/issues.ml
@@ -55,11 +55,12 @@ module Issue124 :
       and b_of_js : Ojs.t -> b = fun js -> { a = (a_of_js js) }
       and b_to_js : b -> Ojs.t = fun { a } -> a_to_js a
       type 'a dummy = Ojs.t
-      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy = fun
-        (type __a) ->
-        fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
-      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t = fun (type
-        __a) -> fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
+      let rec dummy_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a dummy =
+        fun (type __a) ->
+          fun (__a_of_js : Ojs.t -> __a) -> fun (x9 : Ojs.t) -> x9
+      and dummy_to_js : 'a . ('a -> Ojs.t) -> 'a dummy -> Ojs.t =
+        fun (type __a) ->
+          fun (__a_to_js : __a -> Ojs.t) -> fun (x8 : Ojs.t) -> x8
       type 'a wrapped =
         | Wrapped of 'a 
       let rec wrapped_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a wrapped =

--- a/ppx-test/expected/scoped.ml
+++ b/ppx-test/expected/scoped.ml
@@ -88,3 +88,10 @@ module M =
         Ojs.unit_of_js
           (Ojs.apply (Ojs.get_prop_ascii Ojs.global "scope") [||])
   end
+let (d : unit -> unit) =
+  fun () ->
+    ignore
+      (Ojs.call
+         (Ojs.get_prop_ascii
+            (Ojs.get_prop_ascii (Ojs.get_prop_ascii Ojs.global "a") "b") "c")
+         "d" [||])

--- a/ppx-test/expected/types.ml
+++ b/ppx-test/expected/types.ml
@@ -410,42 +410,47 @@ module T :
       let rec parametrized_of_js :
         'a 'b .
           (Ojs.t -> 'a) -> (Ojs.t -> 'b) -> Ojs.t -> ('a, 'b) parametrized
-        = fun (type __a) -> fun (type __b) ->
-        fun (__a_of_js : Ojs.t -> __a) ->
-          fun (__b_of_js : Ojs.t -> __b) ->
-            fun (x130 : Ojs.t) ->
-              {
-                x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
-                y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
-              }
+        =
+        fun (type __a) ->
+          fun (type __b) ->
+            fun (__a_of_js : Ojs.t -> __a) ->
+              fun (__b_of_js : Ojs.t -> __b) ->
+                fun (x130 : Ojs.t) ->
+                  {
+                    x = (__a_of_js (Ojs.get_prop_ascii x130 "x"));
+                    y = (__b_of_js (Ojs.get_prop_ascii x130 "y"))
+                  }
       and parametrized_to_js :
         'a 'b .
           ('a -> Ojs.t) -> ('b -> Ojs.t) -> ('a, 'b) parametrized -> Ojs.t
-        = fun (type __a) -> fun (type __b) ->
-        fun (__a_to_js : __a -> Ojs.t) ->
-          fun (__b_to_js : __b -> Ojs.t) ->
-            fun (x129 : (__a, __b) parametrized) ->
-              Ojs.obj [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
+        =
+        fun (type __a) ->
+          fun (type __b) ->
+            fun (__a_to_js : __a -> Ojs.t) ->
+              fun (__b_to_js : __b -> Ojs.t) ->
+                fun (x129 : (__a, __b) parametrized) ->
+                  Ojs.obj
+                    [|("x", (__a_to_js x129.x));("y", (__b_to_js x129.y))|]
       type 'a abs = ('a -> int) -> unit
-      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs = fun (type
-        __a) ->
-        fun (__a_of_js : Ojs.t -> __a) ->
-          fun (x134 : Ojs.t) ->
-            fun (x135 : __a -> int) ->
-              ignore
-                (Ojs.apply x134
-                   [|(Ojs.fun_to_js 1
-                        (fun (x136 : Ojs.t) ->
-                           Ojs.int_to_js (x135 (__a_of_js x136))))|])
-      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t = fun (type __a)
-        ->
-        fun (__a_to_js : __a -> Ojs.t) ->
-          fun (x131 : (__a -> int) -> unit) ->
-            Ojs.fun_to_js 1
-              (fun (x132 : Ojs.t) ->
-                 x131
-                   (fun (x133 : __a) ->
-                      Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
+      let rec abs_of_js : 'a . (Ojs.t -> 'a) -> Ojs.t -> 'a abs =
+        fun (type __a) ->
+          fun (__a_of_js : Ojs.t -> __a) ->
+            fun (x134 : Ojs.t) ->
+              fun (x135 : __a -> int) ->
+                ignore
+                  (Ojs.apply x134
+                     [|(Ojs.fun_to_js 1
+                          (fun (x136 : Ojs.t) ->
+                             Ojs.int_to_js (x135 (__a_of_js x136))))|])
+      and abs_to_js : 'a . ('a -> Ojs.t) -> 'a abs -> Ojs.t =
+        fun (type __a) ->
+          fun (__a_to_js : __a -> Ojs.t) ->
+            fun (x131 : (__a -> int) -> unit) ->
+              Ojs.fun_to_js 1
+                (fun (x132 : Ojs.t) ->
+                   x131
+                     (fun (x133 : __a) ->
+                        Ojs.int_of_js (Ojs.apply x132 [|(__a_to_js x133)|])))
       type specialized = (int, int) parametrized
       let rec specialized_of_js : Ojs.t -> specialized =
         fun (x140 : Ojs.t) ->

--- a/ppx-test/scoped.mli
+++ b/ppx-test/scoped.mli
@@ -20,3 +20,5 @@ module M : sig
   val global: t
   val invoke: unit -> unit [@@js.invoke]
 end[@js.scope "scope"]
+
+val d: unit -> unit [@@js.scope ("a", "b", "c")] [@@js.global]


### PR DESCRIPTION
Related: #160

This PR makes `@js.scope` accept a tuple payload, which can be used to write a nested scope.

* The example from #160 now can be written as:
  ```ocaml
  module PlacesService: sig
    type t
    val new_places_service: Map.t -> t [@@js.new]
    ...
  end
  [@js.scope ("google", "maps", "places")]
  ```
  
* Custom global object is also supported: assume `fs: require('fs')`, then we can now write
   ```ocaml
   [@@@js.scope (Imports.fs, "promises")]
   ```