### PR TITLE
Wrap functions supplied to Ojs.iter_properties

### DIFF
--- a/lib/ojs.ml
+++ b/lib/ojs.ml
@@ -117,7 +117,10 @@ external new_obj_arr: t -> t -> t = "caml_ojs_new_arr"
 
 let empty_obj () = new_obj (get_prop_ascii global "Object") [||]
 
-external iter_properties: t -> (string -> unit) -> unit = "caml_ojs_iterate_properties"
+external iter_properties_untyped : t -> t -> unit = "caml_ojs_iterate_properties"
+let iter_properties x f =
+  iter_properties_untyped x (fun_to_js 1 (fun x -> f (string_of_js x)))
+
 let apply_arr o arr = call o "apply" [| null; arr |]
 let call_arr o s arr = call (get_prop o (string_to_js s)) "apply" [| o; arr |]
 

--- a/lib/ojs.mli
+++ b/lib/ojs.mli
@@ -89,7 +89,7 @@ external obj: (string * t) array -> t = "caml_js_object"
 val empty_obj: unit -> t
 
 val has_property: t -> string -> bool
-external iter_properties: t -> (string -> unit) -> unit = "caml_ojs_iterate_properties"
+val iter_properties: t -> (string -> unit) -> unit
 
 (** {2 Calling JS functions} *)
 

--- a/lib/ojs_runtime.js
+++ b/lib/ojs_runtime.js
@@ -12,7 +12,7 @@ function caml_ojs_iterate_properties(o, f) {
   var name;
   for(name in o) {
     if(o.hasOwnProperty(name)) {
-      f(caml_js_to_string(name));
+      f(name);
     }
   }
 }


### PR DESCRIPTION
To support effect handlers, we are changing the calling convention of OCaml functions. See https://github.com/ocsigen/js_of_ocaml/pull/1340. Wrapping Ocaml functions is now mandatory to use them from JavaScript.