### PR TITLE
Compatibility with Wasm_of_ocaml

### DIFF
--- a/lib/ojs.ml
+++ b/lib/ojs.ml
@@ -91,7 +91,7 @@ let list_to_js f l =
   array_to_js f (Array.of_list l)
 
 let option_of_js f x =
-  if equals x null || x == undefined then None
+  if equals x null then None
   else Some (f x)
 
 let option_to_js f = function

--- a/lib/ojs.ml
+++ b/lib/ojs.ml
@@ -27,8 +27,8 @@ external int_to_js: int -> t = "%identity"
 external bool_of_js: t -> bool = "caml_js_to_bool"
 external bool_to_js: bool -> t = "caml_js_from_bool"
 
-external float_of_js: t -> float = "%identity"
-external float_to_js: float -> t = "%identity"
+external float_of_js: t -> float = "caml_js_to_float"
+external float_to_js: float -> t = "caml_js_from_float"
 
 external obj: (string * t) array -> t = "caml_js_object"
 

--- a/lib/ojs.mli
+++ b/lib/ojs.mli
@@ -21,8 +21,8 @@ external int_to_js: int -> t = "%identity"
 external bool_of_js: t -> bool = "caml_js_to_bool"
 external bool_to_js: bool -> t = "caml_js_from_bool"
 
-external float_of_js: t -> float = "%identity"
-external float_to_js: float -> t = "%identity"
+external float_of_js: t -> float = "caml_js_to_float"
+external float_to_js: float -> t = "caml_js_from_float"
 
 val array_of_js: (t -> 'a) -> t -> 'a array
 val array_to_js: ('a -> t) -> 'a array -> t


### PR DESCRIPTION
[Wasm_of_ocaml](https://github.com/ocaml-wasm/wasm_of_ocaml) uses a different representation for OCaml floats and JavaScript numbers, so we need explicit coercions (which are still optimized away by Js_of_ocaml).

Also, since JavaScript values get boxed, physical equality can no longer be used to test whether a value is `undefined`.
But as `undefined == null`, I have just simplified the test in `option_of_js`.

The WebAssembly implementation of the runtime functions `caml_ojs_wrap_fun_arguments` and `caml_ojs_iterate_properties` is provided by `wasm_of_ocaml`.