### PR TITLE
Add `[@js.dict]`, `[@@@js.require]`, `[@@js.capitalize]`

### DIFF
--- a/TYPES.md
+++ b/TYPES.md
@@ -16,6 +16,9 @@ The following types are supported out-of-the-box:
  - Sequences of JS-able types: `array` and `list`, both mapped to JS
    arrays (which are assumed to be indexed by integers 0..length-1).
 
+ - Dictionaries of JS-able types: `(string * 'a) list` mapped to
+   a JS object.
+
  - Options on JS-able types.  They are mapped to the same type as
    their parameter: `None` is mapped to JS `null` value, and both
    `null` and `undefined` are mapped back to `None`.  This encoding
@@ -204,6 +207,20 @@ implementation).  Mutually recursive type declarations are supported.
 - Sum type declaration, mapped to enums (see Enums section).
 
 - Sum type declaration with non constant constructors, mapped to records with a discriminator field (see Sum types section).
+
+
+- Association lists, mapped to JS objects
+
+  It is possible to annotate an OCaml type declaration of the form
+  ```
+  (string * ty) list
+  ```
+  (where `ty` is any JS-able type) with `[@js.dict]`. When this is done, values
+  of this type will be mapped to JS objects in the obvious way.
+
+  ```ocaml
+  type t = { headers: ((string * string) list [@js.dict]) }
+  ```
 
 - Arbitrary type with custom mappings
 

--- a/TYPES.md
+++ b/TYPES.md
@@ -181,13 +181,17 @@ implementation).  Mutually recursive type declarations are supported.
   be mutable (but conversions still create copies).
   Polymorphic fields are not yet supported.
 
-  OCaml record values of this type are mapped to JS objects (one
-  property per field).  By default, property names are equal to OCaml
-  labels, but this can be changed manually with a `[@js]` attribute.
+  OCaml record values of this type are mapped to JS objects (one property per
+  field).  By default, property names are equal to the OCaml labels converted to
+  camelCase, but this can be changed manually with a `[@js]` attribute.
 
   ```ocaml
   type myType = { x : int; y : int [@js "Y"]}
   ```
+
+  If one needs the JS labels to be capitalized (ie `CamelCase` instead of
+  `camelCase`) this can be achieved by adding the `[@js.capitalize]` attribute
+  to a record label or `[@@js.capitalize]` to the whole record type declaration.
 
 - Parametrized Type:
 
@@ -492,4 +496,3 @@ end
 You can also create safe bindings manually with the low level functions
 provided by `Ojs` module. See the [section on manually created bindings](LOW_LEVEL_BINDING.md)
 for more information.
-

--- a/VALUES.md
+++ b/VALUES.md
@@ -363,6 +363,28 @@ For instance, the following annotated modules will generate the same code:
   end [@js.scope "inner"] [@js.scope "outer"]
 ```
 
+Require
+-------
+
+The signature attribute `[@@@js.require "name"]` is equivalent to making the
+current global object the result of `require("name")`. This is useful to bind
+Node libraries. For instance,
+
+```ocaml
+module C: sig
+  [@@@js.require "crypto"]
+  type hash
+  val create_hash: unit -> hash [@@js.global]
+end
+```
+
+will bind the `createHash` function of the Node library `crypto`, somewhat as if
+we had written
+```
+const { createHash } = require("crypto")
+```
+in Node.
+
 First-class modules
 -------------------
 

--- a/examples/test/main.ml
+++ b/examples/test/main.ml
@@ -341,3 +341,9 @@ let () =
   | hd :: tl -> Cons (hd, of_list tl)
   in
   Console3.log ([%js.of: int t] (of_list [1;2;3]))
+
+include [%js:
+  [@@@js.require "elephant"]
+  val x : int [@@js.global]
+  val y : string [@@js.global]
+       ]

--- a/examples/test/test_bindings.mli
+++ b/examples/test/test_bindings.mli
@@ -356,3 +356,10 @@ end
 module Dict : sig
   type t = { h : ((string * int) list [@js.dict]) }
 end
+
+module X : sig
+  [@@@js.require "foo"]
+
+  val x : int -> int [@@js.global]
+  val y : string [@@js.global]
+end

--- a/examples/test/test_bindings.mli
+++ b/examples/test/test_bindings.mli
@@ -352,3 +352,7 @@ module Variants : sig
   end
 
 end
+
+module Dict : sig
+  type t = { h : ((string * int) list [@js.dict]) }
+end

--- a/examples/test/test_bindings.mli
+++ b/examples/test/test_bindings.mli
@@ -354,7 +354,8 @@ module Variants : sig
 end
 
 module Dict : sig
-  type t = { h : ((string * int) list [@js.dict]) }
+  type t = { item_chosen : ((string * int) list [@js.dict]) } [@@js.capitalize]
+  type s = { foo: int [@js.capitalize]; bar: string }
 end
 
 module X : sig

--- a/lib/ojs.ml
+++ b/lib/ojs.ml
@@ -121,6 +121,16 @@ external iter_properties_untyped : t -> t -> unit = "caml_ojs_iterate_properties
 let iter_properties x f =
   iter_properties_untyped x (fun_to_js 1 (fun x -> f (string_of_js x)))
 
+let dict_of_js f t =
+  let l = ref [] in
+  iter_properties t (fun k -> l := (k, f (get_prop_ascii t k)) :: !l);
+  !l
+
+let dict_to_js f x =
+  let t = empty_obj () in
+  List.iter (fun (k, v) -> set_prop_ascii t k (f v)) x;
+  t
+
 let apply_arr o arr = call o "apply" [| null; arr |]
 let call_arr o s arr = call (get_prop o (string_to_js s)) "apply" [| o; arr |]
 

--- a/lib/ojs.mli
+++ b/lib/ojs.mli
@@ -42,6 +42,8 @@ val option_to_js: ('a -> t) -> 'a option -> t
 val unit_of_js: t -> unit
 val unit_to_js: unit -> t
 
+val dict_of_js: (t -> 'a) -> t -> (string * 'a) list
+val dict_to_js: ('a -> t) -> (string * 'a) list -> t
 
 (** {2 Wrap OCaml functions as JS functions} *)
 

--- a/ppx-lib/gen_js_api_ppx.ml
+++ b/ppx-lib/gen_js_api_ppx.ml
@@ -208,7 +208,7 @@ let js_name ~global_attrs ?(capitalize = false) name =
   else
     let n = String.length name in
     let buf = Buffer.create n in
-    let capitalize = ref capitalize in
+    let capitalize = ref (has_attribute "js.capitalize" global_attrs || capitalize) in
     for i = 0 to n-1 do
       let c = name.[i] in
       if c = '_' then capitalize := true
@@ -1607,7 +1607,7 @@ let process_fields ctx ~global_attrs l =
   let typ = l.pld_type in
   let jsname =
     match get_string_attribute "js" attrs with
-    | None -> js_name ~global_attrs mlname
+    | None -> js_name ~global_attrs ~capitalize:(has_attribute "js.capitalize" attrs) mlname
     | Some s -> s
   in
   loc,


### PR DESCRIPTION
This PR adds the possibility of annotating an OCaml type expression `(string * ty) list` with `[@js.dict]` to indicate that values of this type should be mapped to JS objects in the obvious way (and vice-versa).