### PR TITLE
remove references to joo_global_object

### DIFF
--- a/lib/ojs.ml
+++ b/lib/ojs.ml
@@ -58,7 +58,7 @@ let undefined = pure_js_expr "undefined"
 
 external equals: t -> t -> bool = "caml_js_equals"
 
-let global = pure_js_expr "joo_global_object"
+let global = pure_js_expr "globalThis"
 
 external new_obj: t -> t array -> t = "caml_js_new"
 

--- a/node-test/bindings/imports.js
+++ b/node-test/bindings/imports.js
@@ -1,4 +1,4 @@
-joo_global_object.__LIB__NODE__IMPORTS = {
+globalThis.__LIB__NODE__IMPORTS = {
   path: require('path'),
   fs: require('fs'),
 };

--- a/node-test/test1/recursive.js
+++ b/node-test/test1/recursive.js
@@ -38,5 +38,5 @@ var Bar = /*#__PURE__*/function () {
   return Bar;
 }();
 
-joo_global_object.Foo = Foo
-joo_global_object.Bar = Bar
+globalThis.Foo = Foo
+globalThis.Bar = Bar


### PR DESCRIPTION
It is deprecated. The js_of_ocaml-compiler will emit a warning when it sees `joo_global_object` in its next release.